### PR TITLE
Adding the implementation of the GitBOM concept in ld linker and readelf tool

### DIFF
--- a/binutils-2.39/bfd/elf-bfd.h
+++ b/binutils-2.39/bfd/elf-bfd.h
@@ -1918,6 +1918,14 @@ struct output_elf_obj_tdata
     asection *sec;
   } build_id;
 
+  /* NT_GITBOM_SHA1 note type info.  */
+  struct
+  {
+    bool (*after_write_object_contents) (bfd *);
+    char **gitoid;
+    asection *sec;
+  } gitbom;
+
   /* FDO_PACKAGING_METADATA note type info.  */
   struct
   {

--- a/binutils-2.39/bfd/elf.c
+++ b/binutils-2.39/bfd/elf.c
@@ -6782,6 +6782,9 @@ _bfd_elf_write_object_contents (bfd *abfd)
   if (t->o->build_id.after_write_object_contents != NULL
       && !(*t->o->build_id.after_write_object_contents) (abfd))
     return false;
+  if (t->o->gitbom.after_write_object_contents != NULL
+      && !(*t->o->gitbom.after_write_object_contents) (abfd))
+    return false;
   if (t->o->package_metadata.after_write_object_contents != NULL
       && !(*t->o->package_metadata.after_write_object_contents) (abfd))
     return false;

--- a/binutils-2.39/binutils/readelf.c
+++ b/binutils-2.39/binutils/readelf.c
@@ -20291,6 +20291,19 @@ print_gnu_note (Filedata * filedata, Elf_Internal_Note *pnote)
   return true;
 }
 
+static bool
+print_gitbom_note (Elf_Internal_Note *pnote)
+{
+  unsigned long i;
+
+  printf (_("    SHA1 GitOID: "));
+  for (i = 0; i < pnote->descsz; ++i)
+    printf ("%02x", pnote->descdata[i] & 0xff);
+  printf ("\n");
+
+  return true;
+}
+
 static const char *
 get_v850_elf_note_type (enum v850_notes n_type)
 {
@@ -21502,6 +21515,10 @@ process_note (Elf_Internal_Note *  pnote,
     /* GNU-specific object file notes.  */
     nt = get_gnu_elf_note_type (pnote->type);
 
+  else if (startswith (pnote->namedata, "GITBOM"))
+    /* GitBOM-specific object file notes.  */
+    nt = _("NT_GITBOM (SHA1 GITOID)");
+
   else if (startswith (pnote->namedata, "AMDGPU"))
     /* AMDGPU-specific object file notes.  */
     nt = get_amdgpu_elf_note_type (pnote->type);
@@ -21565,6 +21582,8 @@ process_note (Elf_Internal_Note *  pnote,
     return print_ia64_vms_note (pnote);
   else if (startswith (pnote->namedata, "GNU"))
     return print_gnu_note (filedata, pnote);
+  else if (startswith (pnote->namedata, "GITBOM"))
+    return print_gitbom_note (pnote);
   else if (startswith (pnote->namedata, "stapsdt"))
     return print_stapsdt_note (pnote);
   else if (startswith (pnote->namedata, "CORE"))

--- a/binutils-2.39/include/elf/common.h
+++ b/binutils-2.39/include/elf/common.h
@@ -796,6 +796,10 @@
 #define NT_ARCH		2		/* Contains an architecture string.  */
 #define NT_GO_BUILDID	4		/* Contains GO buildid data.  */
 
+/* Values for notes regarding GitBOM concept.  */
+
+#define NT_GITBOM_SHA1		1
+
 /* Values for notes in non-core files using name "GNU".  */
 
 #define NT_GNU_ABI_TAG		1

--- a/binutils-2.39/ld/ld.h
+++ b/binutils-2.39/ld/ld.h
@@ -284,6 +284,10 @@ typedef struct
 
   char *dependency_file;
 
+  /* The path to the directory where GitBOM information should be
+     placed, unless GITBOM_DIR environment variable is set.  */
+  char *gitbom_dir;
+
   unsigned int split_by_reloc;
   bfd_size_type split_by_file;
 

--- a/binutils-2.39/ld/ld.info
+++ b/binutils-2.39/ld/ld.info
@@ -622,6 +622,15 @@ GNU linker:
      installation where it was produced, and should not be copied into
      distributed makefiles without careful editing.
 
+'--gitbom'
+'--gitbom=DIRECTORY'
+     Calculate the 'GitBOM' information.  Use DIRECTORY as the path to the
+     directory in which 'GitBOM' information should be stored.  This option
+     has precedence over the default case (when DIRECTORY is not
+     specified), but lower priority compared to the 'GITBOM_DIR'
+     environment variable.  In the default case, 'GitBOM' information is
+     stored in the same directory as the resulting executable.
+
 '-O LEVEL'
      If LEVEL is a numeric values greater than zero 'ld' optimizes the
      output.  This might take significantly longer and therefore
@@ -8378,7 +8387,7 @@ File: ld.info,  Node: LD Index,  Prev: GNU Free Documentation License,  Up: Top
 LD Index
 ********
 
- [index ]
+\00[index\00]
 * Menu:
 
 * ":                                     Symbols.            (line    6)
@@ -8486,6 +8495,8 @@ LD Index
 * --format=VERSION:                      TI COFF.            (line    6)
 * --gc-keep-exported:                    Options.            (line 1453)
 * --gc-sections:                         Options.            (line 1415)
+* --gitbom:                              Options.            (line 625)
+* --gitbom=DIRECTORY:                    Options.            (line 625)
 * --got:                                 Options.            (line 2808)
 * --got=TYPE:                            M68K.               (line    6)
 * --gpsize=VALUE:                        Options.            (line  347)

--- a/binutils-2.39/ld/ld.texi
+++ b/binutils-2.39/ld/ld.texi
@@ -909,6 +909,17 @@ linker, unlike ``system headers'' in the compiler).  So the output from
 installation where it was produced, and should not be copied into
 distributed makefiles without careful editing.
 
+@kindex --gitbom
+@kindex --gitbom=@var{directory}
+@item --gitbom
+@itemx --gitbom=@var{directory}
+Calculate the @code{GitBOM} information.  Use @var{directory} as the path
+to the directory in which @code{GitBOM} information should be stored.  This
+option has precedence over the default case (when @var{directory} is not
+specified), but lower priority compared to the @code{GITBOM_DIR}
+environment variable.  In the default case, @code{GitBOM} information is
+stored in the same directory as the resulting executable.
+
 @kindex -O @var{level}
 @cindex generating optimized output
 @item -O @var{level}

--- a/binutils-2.39/ld/ldelf.h
+++ b/binutils-2.39/ld/ldelf.h
@@ -19,6 +19,7 @@
    MA 02110-1301, USA.  */
 
 extern const char *ldelf_emit_note_gnu_build_id;
+extern char *ldelf_emit_note_gitbom;
 extern const char *ldelf_emit_note_fdo_package_metadata;
 
 extern void ldelf_after_parse (void);
@@ -27,6 +28,7 @@ extern void ldelf_before_plugin_all_symbols_read (int, int, int, int,
 						  int, const char *);
 extern void ldelf_after_open (int, int, int, int, int, const char *);
 extern bool ldelf_setup_build_id (bfd *);
+extern bool ldelf_setup_gitbom (bfd *);
 extern bool ldelf_setup_package_metadata (bfd *);
 extern void ldelf_append_to_separated_string (char **, char *);
 extern void ldelf_before_allocation (char *, char *, const char *);

--- a/binutils-2.39/ld/ldlex.h
+++ b/binutils-2.39/ld/ldlex.h
@@ -168,6 +168,7 @@ enum option_values
   OPTION_NO_WARN_EXECSTACK,
   OPTION_WARN_RWX_SEGMENTS,
   OPTION_NO_WARN_RWX_SEGMENTS,
+  OPTION_GITBOM,
 };
 
 /* The initial parser states.  */

--- a/binutils-2.39/ld/ldmain.h
+++ b/binutils-2.39/ld/ldmain.h
@@ -63,4 +63,6 @@ extern void add_ignoresym (struct bfd_link_info *, const char *);
 extern void add_keepsyms_file (const char *);
 extern void track_dependency_files (const char *);
 
+extern void gitbom_add_to_bom_sections (const char *, char *, unsigned long);
+
 #endif

--- a/binutils-2.39/ld/lexsup.c
+++ b/binutils-2.39/ld/lexsup.c
@@ -41,6 +41,7 @@
 #include "ldver.h"
 #include "ldemul.h"
 #include "demangle.h"
+#include "ldelf.h"
 #if BFD_SUPPORTS_PLUGINS
 #include "plugin.h"
 #endif /* BFD_SUPPORTS_PLUGINS */
@@ -145,6 +146,8 @@ static const struct ld_option ld_options[] =
   { {"gpsize", required_argument, NULL, 'G'},
     'G', N_("SIZE"), N_("Small data size (if no size, same as --shared)"),
     TWO_DASHES },
+  { {"gitbom", optional_argument, NULL, OPTION_GITBOM},
+    '\0', N_("DIRECTORY"), N_("Calculate GitBOM information"), TWO_DASHES },
   { {"soname", required_argument, NULL, OPTION_SONAME},
     'h', N_("FILENAME"), N_("Set internal name of shared library"), ONE_DASH },
   { {"dynamic-linker", required_argument, NULL, OPTION_DYNAMIC_LINKER},
@@ -1741,6 +1744,14 @@ parse_args (unsigned argc, char **argv)
 	    config.ctf_share_duplicated = true;
 	  else
 	    einfo (_("%F%P: bad --ctf-share-types option: %s\n"), optarg);
+	  break;
+
+	case OPTION_GITBOM:
+	  ldelf_emit_note_gitbom = (char *) xcalloc (40 + 1, sizeof (char));
+	  if (optarg != NULL)
+	    config.gitbom_dir = optarg;
+	  else
+	    config.gitbom_dir = "";
 	  break;
 	}
     }

--- a/binutils-2.39/ld/testsuite/ld-elf/gitbom.exp
+++ b/binutils-2.39/ld/testsuite/ld-elf/gitbom.exp
@@ -1,0 +1,91 @@
+# Expect script for GitBOM calculation tests.
+#   Copyright (C) 2021-2022 Free Software Foundation, Inc.
+#
+# This file is part of the GNU Binutils.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston,
+# MA 02110-1301, USA.
+#
+
+# Exclude non-ELF targets.
+
+if ![is_elf_format] {
+    return
+}
+
+proc check_gitbom_document_contents { gitbom_file test_name } {
+    if [file exists $gitbom_file] then {
+        set file_a [open $gitbom_file r]
+    } else {
+        perror "$gitbom_file doesn't exist"
+    }
+
+    set eof -1
+    set list_a {}
+
+    while { [gets $file_a line] != $eof } {
+        lappend list_a $line
+    }
+    close $file_a
+
+    if { [regexp "^gitoid:blob:sha1 {blob d138dc90198e9370085e65f8bfec82d81e245c56}$" $list_a] } then {
+        pass $test_name
+    } else {
+        perror "$list_a"
+        fail $test_name
+    }
+    return 0
+}
+
+set env(GITBOM_DIR) "env_dir"
+
+run_ld_link_tests [list \
+    [list \
+	"GitBOM calculation with GITBOM_DIR and --gitbom" \
+	"-r --gitbom" \
+	"" \
+	"" \
+	{dummy.s} \
+	{{readelf {--notes} gitbom.rd}} \
+	"gitbom1.o" \
+    ] \
+    [list \
+	"GitBOM calculation with GITBOM_DIR" \
+	"-r" \
+	"" \
+	"" \
+	{dummy.s} \
+	{{readelf {--notes} gitbom.rd}} \
+	"gitbom2.o" \
+    ] \
+]
+
+check_gitbom_document_contents "env_dir/.gitbom/objects/sha1/05/33256bbdc60cd8d714d4f54d0d81c0964b7db6" "GitBOM Document file contents 1"
+
+unset env(GITBOM_DIR)
+
+run_ld_link_tests [list \
+    [list \
+	"GitBOM calculation with --gitbom" \
+	"-r --gitbom=dir" \
+	"" \
+	"" \
+	{dummy.s} \
+	{{readelf {--notes} gitbom.rd}} \
+	"gitbom3.o" \
+    ] \
+]
+
+check_gitbom_document_contents "dir/.gitbom/objects/sha1/05/33256bbdc60cd8d714d4f54d0d81c0964b7db6" "GitBOM Document file contents 2"

--- a/binutils-2.39/ld/testsuite/ld-elf/gitbom.rd
+++ b/binutils-2.39/ld/testsuite/ld-elf/gitbom.rd
@@ -1,0 +1,6 @@
+#...
+Displaying notes found in: \.note\.gitbom
+  Owner                Data size 	Description
+  GITBOM               0x00000014	NT_GITBOM \(SHA1 GITOID\)
+    SHA1 GitOID: [0-9a-f]+
+#pass


### PR DESCRIPTION
This PR adds the implementation of the GitBOM concept in the ld linker and readelf tool.
It includes:
            1) The creation of the ELF NOTE .note.gitbom section in the resulting executable, when GitBOM calculation is enabled.
            2) The creation of the GitBOM Document file in the desired directory in the specified format (see the GitBOM
            specification), when GitBOM calculation is enabled.
            3) The possibility of specifying the directory in which the GitBOM Document will be stored (GITBOM_DIR environment
            variable, --gitbom=<dir> option, or the default case which is the --gitbom option).
            4) The support for a better representation of the .note.gitbom section, when specifying the option --notes with readelf
            tool.
            5) Basic tests to ensure the .note.gitbom section and the GitBOM Document file are created, when the GitBOM
            calculation is enabled.

Signed-off-by: Vojislav Tomasevic <vojislav.tomasevic@syrmia.com>