### PR TITLE
Fixing the issues found while building OpenSSL and Linux kernel

### DIFF
--- a/binutils-2.39/ld/ldelf.c
+++ b/binutils-2.39/ld/ldelf.c
@@ -1323,7 +1323,6 @@ ldelf_after_open (int use_libpath, int native, int is_linux, int is_freebsd,
       s = bfd_get_section_by_name (abfd, ".note.omnibor");
       if (s != NULL)
         {
-          s->flags |= SEC_EXCLUDE;
           if (config.omnibor_dir != NULL ||
 	     (getenv ("OMNIBOR_DIR") != NULL && strlen (getenv ("OMNIBOR_DIR")) > 0))
 	    {
@@ -1335,8 +1334,8 @@ ldelf_after_open (int use_libpath, int native, int is_linux, int is_freebsd,
 			(char *) xcalloc (2 * GITOID_LENGTH_SHA1 + 1, sizeof (char));
               bfd_get_section_contents (abfd, s, sec_contents_sha1, 0,
 					20 + GITOID_LENGTH_SHA1);
-              strncpy (sec_contents_gitoid_sha1, sec_contents_sha1 + GITOID_LENGTH_SHA1,
-		       GITOID_LENGTH_SHA1);
+              memcpy (sec_contents_gitoid_sha1, sec_contents_sha1 + GITOID_LENGTH_SHA1,
+		      GITOID_LENGTH_SHA1);
               convert_ascii_decimal_to_ascii_hex (sec_contents_gitoid_sha1,
 						  sec_contents_fin_sha1,
 						  GITOID_LENGTH_SHA1);
@@ -1351,8 +1350,8 @@ ldelf_after_open (int use_libpath, int native, int is_linux, int is_freebsd,
               bfd_get_section_contents (abfd, s, sec_contents_sha256,
 					20 + GITOID_LENGTH_SHA1,
 					20 + GITOID_LENGTH_SHA256);
-              strncpy (sec_contents_gitoid_sha256, sec_contents_sha256 + 20,
-		       GITOID_LENGTH_SHA256);
+              memcpy (sec_contents_gitoid_sha256, sec_contents_sha256 + 20,
+		      GITOID_LENGTH_SHA256);
               convert_ascii_decimal_to_ascii_hex (sec_contents_gitoid_sha256,
 						  sec_contents_fin_sha256,
 						  GITOID_LENGTH_SHA256);
@@ -1369,6 +1368,9 @@ ldelf_after_open (int use_libpath, int native, int is_linux, int is_freebsd,
               free (sec_contents_gitoid_sha1);
               free (sec_contents_sha1);
             }
+          s->flags |= SEC_EXCLUDE;
+          bfd_section_list_remove (abfd, s);
+	  abfd->section_count--;
         }
     }
 

--- a/binutils-2.39/ld/ldmain.c
+++ b/binutils-2.39/ld/ldmain.c
@@ -52,7 +52,7 @@
 
 #define GITOID_LENGTH_SHA1 20
 #define GITOID_LENGTH_SHA256 32
-#define MAX_LONG_SIZE_STRING_LENGTH 256
+#define MAX_FILE_SIZE_STRING_LENGTH 256
 
 /* Somewhere above, sys/stat.h got included.  */
 #if !defined(S_ISDIR) && defined(S_IFDIR)
@@ -551,7 +551,7 @@ calculate_sha1_omnibor (FILE *dep_file, unsigned char resblock[])
 
   /* This length should be enough for everything up to 64B, which should
      cover long type.  */
-  char buff_for_file_size[MAX_LONG_SIZE_STRING_LENGTH];
+  char buff_for_file_size[MAX_FILE_SIZE_STRING_LENGTH];
   sprintf (buff_for_file_size, "%ld", file_size);
 
   char *init_data = (char *) xcalloc (1, sizeof (char));
@@ -588,7 +588,7 @@ calculate_sha1_omnibor_with_contents (char *contents,
 
   /* This length should be enough for everything up to 64B, which should
      cover long type.  */
-  char buff_for_file_size[MAX_LONG_SIZE_STRING_LENGTH];
+  char buff_for_file_size[MAX_FILE_SIZE_STRING_LENGTH];
   sprintf (buff_for_file_size, "%ld", file_size);
 
   char *init_data = (char *) xcalloc (1, sizeof (char));
@@ -622,7 +622,7 @@ calculate_sha256_omnibor (FILE *dep_file, unsigned char resblock[])
 
   /* This length should be enough for everything up to 64B, which should
      cover long type.  */
-  char buff_for_file_size[MAX_LONG_SIZE_STRING_LENGTH];
+  char buff_for_file_size[MAX_FILE_SIZE_STRING_LENGTH];
   sprintf (buff_for_file_size, "%ld", file_size);
 
   char *init_data = (char *) xcalloc (1, sizeof (char));
@@ -659,7 +659,7 @@ calculate_sha256_omnibor_with_contents (char *contents,
 
   /* This length should be enough for everything up to 64B, which should
      cover long type.  */
-  char buff_for_file_size[MAX_LONG_SIZE_STRING_LENGTH];
+  char buff_for_file_size[MAX_FILE_SIZE_STRING_LENGTH];
   sprintf (buff_for_file_size, "%ld", file_size);
 
   char *init_data = (char *) xcalloc (1, sizeof (char));


### PR DESCRIPTION
This PR fixes the issues which were found while using these OmniBOR-enabled BinUtils sources to build the OpenSSL project and Linux kernel. The issues were:
                    1) When relocatable object files were built in Linux kernel, the '.note.omnibor' section from their dependencies were not eliminated, because SEC_EXCLUDE indicator does not apply to them. Therefore, a manual removal of input '.note.omnibor' sections was introduced.
                    2) The usage of strcpy/strncpy/strcat is replaced with the usage of memcpy, since it does not look for null terminating characters (there was an issue where gitoids contained null terminating characters in the middle of them).
                    3) The length of the buff_for_file_size array was changed so as to reflect the state in the corresponding OmniBOR implementation in GCC.