### PR TITLE
Adding the implementation of the OmniBOR concept in the as tool

### DIFF
--- a/binutils-2.39/gas/as.c
+++ b/binutils-2.39/gas/as.c
@@ -1571,7 +1571,7 @@ main (int argc, char ** argv)
             {
 	      char *res = (char *) xcalloc (1, sizeof (char));
 
-              omnibor_get_destdir (getenv ("COLLECT_GCC_OPTIONS"), &res);
+              omnibor_get_destdir (&res);
               if (strlen (res) > 0)
                 omnibor_set_contents (&omnibor_dir_final, res, strlen (res));
               else
@@ -1596,6 +1596,8 @@ main (int argc, char ** argv)
 
       if (strcmp ("", gitoid_sha1) != 0 && strcmp ("", gitoid_sha256) != 0)
 	write_omnibor (gitoid_sha1, gitoid_sha256);
+      else
+	as_fatal (_("Error in creation of OmniBOR Document files"));
 
       omnibor_clear_deps ();
       omnibor_clear_note_sections ();

--- a/binutils-2.39/gas/as.h
+++ b/binutils-2.39/gas/as.h
@@ -184,7 +184,8 @@ COMMON segT now_seg;
 
 #define segment_name(SEG)	bfd_section_name (SEG)
 
-extern segT reg_section, expr_section;
+extern segT reg_section, expr_section, input_omnibor_section,
+	    output_omnibor_section;
 /* Shouldn't these be eliminated someday?  */
 extern segT text_section, data_section, bss_section;
 #define absolute_section	bfd_abs_section_ptr
@@ -489,6 +490,27 @@ void   start_dependencies (char *);
 void   register_dependency (const char *);
 void   print_dependencies (void);
 segT   subseg_get (const char *, int);
+
+/* OmniBOR-related function declarations.  Defined in depend.c.  */
+void omnibor_start_dependencies (void);
+bool is_omnibor_enabled (void);
+void omnibor_set_contents (char **, const char *, unsigned long);
+void omnibor_add_to_note_sections (const char *, char *, char *,
+				   unsigned long, unsigned long);
+void omnibor_clear_deps (void);
+void omnibor_clear_note_sections (void);
+void omnibor_get_destdir (const char *, char **);
+void write_sha1_omnibor (char **, const char *);
+void write_sha256_omnibor (char **, const char *);
+void create_sha1_symlink (const char *, char *);
+void create_sha256_symlink (const char *, char *);
+
+/* More OmniBOR-related function declarations.  Defined in write.c.  */
+void write_omnibor (const char *, const char *);
+
+/* OmniBOR-related variable declarations.  Defined in as.c.  */
+extern const char *omnibor_dir;
+extern const char *omnibor_input_filename;
 
 char *remap_debug_filename (const char *);
 void add_debug_prefix_map (const char *);

--- a/binutils-2.39/gas/as.h
+++ b/binutils-2.39/gas/as.h
@@ -499,7 +499,7 @@ void omnibor_add_to_note_sections (const char *, char *, char *,
 				   unsigned long, unsigned long);
 void omnibor_clear_deps (void);
 void omnibor_clear_note_sections (void);
-void omnibor_get_destdir (const char *, char **);
+void omnibor_get_destdir (char **);
 void write_sha1_omnibor (char **, const char *);
 void write_sha256_omnibor (char **, const char *);
 void create_sha1_symlink (const char *, char *);

--- a/binutils-2.39/gas/depend.c
+++ b/binutils-2.39/gas/depend.c
@@ -20,8 +20,18 @@
 
 #include "as.h"
 #include "filenames.h"
+#include "sha1.h"
+#include "sha256.h"
+#include <dirent.h>
 
-/* The file to write to, or NULL if no dependencies being kept.  */
+#define GITOID_LENGTH_SHA1 20
+#define GITOID_LENGTH_SHA256 32
+#define MAX_FILE_SIZE_STRING_LENGTH 256
+
+/* The file to write to, or NULL if no dependencies being kept
+   (it can also be NULL if the OmniBOR information calculation
+   is enabled, which inherently enables keeping dependencies,
+   but it does not have to be NULL in such case).  */
 static char * dep_file = NULL;
 
 struct dependency
@@ -33,6 +43,10 @@ struct dependency
 /* All the files we depend on.  */
 static struct dependency * dep_chain = NULL;
 
+/* Flag which indicates whether the OmniBOR information calculation
+   is enabled or not.  */
+static bool omnibor_enabled = false;
+
 /* Current column in output file.  */
 static int column = 0;
 
@@ -43,12 +57,35 @@ static void wrap_output (FILE *, const char *, int);
 #define MAX_COLUMNS 72
 
 /* Start saving dependencies, to be written to FILENAME.  If this is
-   never called, then dependency tracking is simply skipped.  */
+   never called, then dependency tracking is simply skipped (unless
+   the OmniBOR information calculation is enabled - see
+   omnibor_start_dependencies function).  */
 
 void
 start_dependencies (char *filename)
 {
   dep_file = filename;
+}
+
+/* Another way to start saving dependencies.  If neither this nor
+   start_dependencies function is called, then dependency
+   tracking is simply skipped.  This function just enables
+   the tracking of dependencies, but they cannot be written in
+   a file later on, unless start_dependencies function is called
+   as well.  */
+
+void
+omnibor_start_dependencies (void)
+{
+  omnibor_enabled = true;
+}
+
+/*  Check whether the OmniBOR calculation is enabled or not.  */
+
+bool
+is_omnibor_enabled (void)
+{
+  return omnibor_enabled;
 }
 
 /* Noticed a new filename, so try to register it.  */
@@ -58,7 +95,7 @@ register_dependency (const char *filename)
 {
   struct dependency *dep;
 
-  if (dep_file == NULL)
+  if (dep_file == NULL && !omnibor_enabled)
     return;
 
   for (dep = dep_chain; dep != NULL; dep = dep->next)
@@ -204,4 +241,1301 @@ print_dependencies (void)
 
   if (fclose (f))
     as_warn (_("can't close `%s'"), dep_file);
+}
+
+/* OmniBOR struct which contains the names of the directories from the path
+   to the directory where the OmniBOR information is to be stored.  */
+
+struct omnibor_dirs
+{
+  struct omnibor_dirs *next;
+  DIR *dir;
+};
+
+static struct omnibor_dirs *omnibor_dirs_head, *omnibor_dirs_tail;
+
+static void
+omnibor_add_to_dirs (DIR **directory)
+{
+  struct omnibor_dirs *elem
+    = (struct omnibor_dirs *) xmalloc (sizeof (*elem));
+  elem->dir = *directory;
+  elem->next = NULL;
+  if (omnibor_dirs_head == NULL)
+    omnibor_dirs_head = elem;
+  else
+    omnibor_dirs_tail->next = elem;
+  omnibor_dirs_tail = elem;
+}
+
+/* Return the position of the first occurrence after start_pos position
+   of char c in str string (start_pos is the first position to check).  */
+
+static int
+omnibor_find_char_from_pos (unsigned start_pos, char c, const char *str)
+{
+  for (unsigned ix = start_pos; ix < strlen (str); ix++)
+    if (str[ix] == c)
+      return ix;
+
+  return -1;
+}
+
+/* Return the position of the last occurrence of char c in the entire
+   str string.  */
+
+static int
+omnibor_find_last_of (char c, const char *str)
+{
+  int ret = -1;
+  for (unsigned ix = 0; ix < strlen (str); ix++)
+    if (str[ix] == c)
+      ret = ix;
+
+  return ret;
+}
+
+/* Append the string str2 to the end of the string str1.  */
+
+static void
+omnibor_append_to_string (char **str1, const char *str2,
+			 unsigned long len1, unsigned long len2)
+{
+  *str1 = (char *) xrealloc
+	(*str1, sizeof (char) * (len1 + len2 + 1));
+  memcpy (*str1 + len1, str2, len2);
+  (*str1)[len1 + len2] = '\0';
+}
+
+/* Add the string str2 as a prefix to the string str1.  */
+
+static void
+omnibor_add_prefix_to_string (char **str1, const char *str2)
+{
+  unsigned len1 = strlen (*str1), len2 = strlen (str2);
+  char *temp = (char *) xcalloc
+	(len1 + len2 + 1, sizeof (char));
+  memcpy (temp, str2, len2);
+  memcpy (temp + len2, *str1, len1);
+  temp[len1 + len2] = '\0';
+  *str1 = (char *) xrealloc
+	(*str1, sizeof (char) * (len1 + len2 + 1));
+  memcpy (*str1, temp, len1 + len2);
+  (*str1)[len1 + len2] = '\0';
+  free (temp);
+}
+
+/* Get the substring of length len of the str2 string starting from
+   the start position and put it in the str1 string.  */
+
+static void
+omnibor_substr (char **str1, unsigned start, unsigned len, const char *str2)
+{
+  *str1 = (char *) xrealloc
+	(*str1, sizeof (char) * (len + 1));
+  memcpy (*str1, str2 + start, len);
+  (*str1)[len] = '\0';
+}
+
+/* Set the string str1 to have the contents of the string str2.  */
+
+void
+omnibor_set_contents (char **str1, const char *str2, unsigned long len)
+{
+  *str1 = (char *) xrealloc
+	(*str1, sizeof (char) * (len + 1));
+  memcpy (*str1, str2, len);
+  (*str1)[len] = '\0';
+}
+
+/* Get the path of the directory where the resulting object file will be
+   stored, because the OmniBOR information should be stored there as well,
+   in the default case (when OMNIBOR_DIR environment variable is not set
+   and --omnibor=<arg> is not used, but --omnibor is used instead).  */
+
+void
+omnibor_get_destdir (const char *gcc_opts, char **res)
+{
+  char *path = (char *) xcalloc (1, sizeof (char));
+  char *temp = (char *) xcalloc (1, sizeof (char));
+
+  int old_i = 0, i = 0;
+  while ((i = omnibor_find_char_from_pos (i, ' ', gcc_opts)) != -1)
+    {
+      omnibor_substr (&temp, old_i, i - old_i, gcc_opts);
+      if (strcmp ("'-o'", temp) == 0)
+        {
+          i = i + 1;
+	  old_i = i;
+
+          if ((i = omnibor_find_char_from_pos (i, ' ', gcc_opts)) != -1)
+            {
+              omnibor_substr (&temp, old_i + 1, i - old_i - 2, gcc_opts);
+              omnibor_set_contents (&path, temp, strlen (temp));
+	      i = i + 1;
+	      old_i = i;
+            }
+        }
+      else
+        {
+          i = i + 1;
+	  old_i = i;
+        }
+    }
+
+  /* Last argument cannot be '-o' because gcc error will be raised that a
+     filename is missing after that option in that case.  */
+  i = -1;
+
+  /* If there was a valid '-o' option, parse the directory part of the path
+     and put it in the res parameter.  */
+  if ((i = omnibor_find_last_of ('/', path)) != -1)
+    {
+      omnibor_substr (&temp, 0, i, path);
+      omnibor_set_contents (res, temp, strlen (temp));
+    }
+  else
+    omnibor_set_contents (res, "", 0);
+
+  free (temp);
+  free (path);
+}
+
+/* Open all the directories from the path specified in the res_dir
+   parameter and put them in the omnibor_dirs_head list.  Also, create
+   the directories which do not already exist.  */
+
+static DIR *
+open_all_directories_in_path (const char *res_dir)
+{
+  char *path = (char *) xcalloc (1, sizeof (char));
+  char *dir_name = (char *) xcalloc (1, sizeof (char));
+
+  int old_p = 0, p = omnibor_find_char_from_pos (0, '/', res_dir);
+  int dfd, absolute = 0;
+  DIR *dir = NULL;
+
+  if (p == -1)
+    {
+      free (dir_name);
+      free (path);
+      return NULL;
+    }
+  /* If the res_dir is an absolute path.  */
+  else if (p == 0)
+    {
+      absolute = 1;
+      omnibor_append_to_string (&path, "/", strlen (path), strlen ("/"));
+      /* Opening a root directory because an absolute path is specified.  */
+      dir = opendir (path);
+      dfd = dirfd (dir);
+
+      omnibor_add_to_dirs (&dir);
+      p = p + 1;
+      old_p = p;
+
+      /* Path is of format "/<dir>" where <dir> does not exist.  This point can be
+         reached only if <dir> could not be created in the root folder, so it is
+         considered as an illegal path.  */
+      if ((p = omnibor_find_char_from_pos (p, '/', res_dir)) == -1)
+        {
+	  free (dir_name);
+	  free (path);
+	  return NULL;
+	}
+
+      /* Process sequences of adjacent occurrences of character '/'.  */
+      while (old_p == p)
+        {
+          p = p + 1;
+          old_p = p;
+          p = omnibor_find_char_from_pos (p, '/', res_dir);
+        }
+
+      if (p == -1)
+        {
+	  free (dir_name);
+	  free (path);
+	  return NULL;
+	}
+    }
+
+  omnibor_substr (&dir_name, old_p, p - old_p, res_dir);
+  omnibor_append_to_string (&path, dir_name, strlen (path), strlen (dir_name));
+
+  if ((dir = opendir (path)) == NULL)
+    {
+      if (absolute)
+        mkdirat (dfd, dir_name, S_IRWXU);
+      else
+        mkdir (dir_name, S_IRWXU);
+      dir = opendir (path);
+    }
+
+  if (dir == NULL)
+    {
+      free (dir_name);
+      free (path);
+      return NULL;
+    }
+
+  dfd = dirfd (dir);
+
+  omnibor_add_to_dirs (&dir);
+  p = p + 1;
+  old_p = p;
+
+  while ((p = omnibor_find_char_from_pos (p, '/', res_dir)) != -1)
+    {
+      /* Process sequences of adjacent occurrences of character '/'.  */
+      while (old_p == p)
+        {
+          p = p + 1;
+          old_p = p;
+          p = omnibor_find_char_from_pos (p, '/', res_dir);
+        }
+
+      if (p == -1)
+        break;
+
+      omnibor_substr (&dir_name, old_p, p - old_p, res_dir);
+      omnibor_append_to_string (&path, "/", strlen (path), strlen ("/"));
+      omnibor_append_to_string (&path, dir_name, strlen (path),
+				strlen (dir_name));
+
+      if ((dir = opendir (path)) == NULL)
+        {
+          mkdirat (dfd, dir_name, S_IRWXU);
+          dir = opendir (path);
+        }
+
+      if (dir == NULL)
+        {
+	  free (dir_name);
+	  free (path);
+	  return NULL;
+	}
+
+      dfd = dirfd (dir);
+
+      omnibor_add_to_dirs (&dir);
+      p = p + 1;
+      old_p = p;
+    }
+
+  if ((unsigned) old_p < strlen (res_dir))
+    {
+      omnibor_substr (&dir_name, old_p, strlen (res_dir) - old_p, res_dir);
+      omnibor_append_to_string (&path, "/", strlen (path), strlen ("/"));
+      omnibor_append_to_string (&path, dir_name, strlen (path),
+				strlen (dir_name));
+
+      if ((dir = opendir (path)) == NULL)
+        {
+          mkdirat (dfd, dir_name, S_IRWXU);
+          dir = opendir (path);
+        }
+
+      omnibor_add_to_dirs (&dir);
+    }
+
+  free (dir_name);
+  free (path);
+  return dir;
+}
+
+/* Close all the directories from the omnibor_dirs_head list.  This function
+   should be called after calling the function open_all_directories_in_path.  */
+
+static void
+close_all_directories_in_path (void)
+{
+  struct omnibor_dirs *dir = omnibor_dirs_head, *old = NULL;
+  while (dir != NULL)
+    {
+      closedir (dir->dir);
+      old = dir;
+      dir = dir->next;
+      free (old);
+    }
+
+  omnibor_dirs_head = NULL;
+  omnibor_dirs_tail = NULL;
+}
+
+/* Calculate the SHA1 gitoid using the contents of the given file.  */
+
+static void
+calculate_sha1_omnibor (FILE *dependency_file, unsigned char resblock[])
+{
+  fseek (dependency_file, 0L, SEEK_END);
+  long file_size = ftell (dependency_file);
+  fseek (dependency_file, 0L, SEEK_SET);
+
+  /* This length should be enough for everything up to 64B, which should
+     cover long type.  */
+  char buff_for_file_size[MAX_FILE_SIZE_STRING_LENGTH];
+  sprintf (buff_for_file_size, "%ld", file_size);
+
+  char *init_data = (char *) xcalloc (1, sizeof (char));
+  omnibor_append_to_string (&init_data, "blob ", strlen (init_data),
+			    strlen ("blob "));
+  omnibor_append_to_string (&init_data, buff_for_file_size, strlen (init_data),
+			    strlen (buff_for_file_size));
+  omnibor_append_to_string (&init_data, "\0", strlen (init_data), 1);
+
+  char *file_contents = (char *) xcalloc (file_size, sizeof (char));
+  fread (file_contents, 1, file_size, dependency_file);
+
+  /* Calculate the hash.  */
+  struct sha1_ctx ctx;
+
+  sha1_init_ctx (&ctx);
+
+  sha1_process_bytes (init_data, strlen (init_data) + 1, &ctx);
+  sha1_process_bytes (file_contents, file_size, &ctx);
+
+  sha1_finish_ctx (&ctx, resblock);
+
+  free (file_contents);
+  free (init_data);
+}
+
+/* Calculate the SHA1 gitoid using the given contents.  */
+
+static void
+calculate_sha1_omnibor_with_contents (char *contents,
+				      unsigned char resblock[])
+{
+  long file_size = strlen (contents);
+
+  /* This length should be enough for everything up to 64B, which should
+     cover long type.  */
+  char buff_for_file_size[MAX_FILE_SIZE_STRING_LENGTH];
+  sprintf (buff_for_file_size, "%ld", file_size);
+
+  char *init_data = (char *) xcalloc (1, sizeof (char));
+  omnibor_append_to_string (&init_data, "blob ", strlen (init_data),
+			    strlen ("blob "));
+  omnibor_append_to_string (&init_data, buff_for_file_size, strlen (init_data),
+			    strlen (buff_for_file_size));
+  omnibor_append_to_string (&init_data, "\0", strlen (init_data), 1);
+
+  /* Calculate the hash.  */
+  struct sha1_ctx ctx;
+
+  sha1_init_ctx (&ctx);
+
+  sha1_process_bytes (init_data, strlen (init_data) + 1, &ctx);
+  sha1_process_bytes (contents, file_size, &ctx);
+
+  sha1_finish_ctx (&ctx, resblock);
+
+  free (init_data);
+}
+
+/* Calculate the SHA256 gitoid using the contents of the given file.  */
+
+static void
+calculate_sha256_omnibor (FILE *dependency_file, unsigned char resblock[])
+{
+  fseek (dependency_file, 0L, SEEK_END);
+  long file_size = ftell (dependency_file);
+  fseek (dependency_file, 0L, SEEK_SET);
+
+  /* This length should be enough for everything up to 64B, which should
+     cover long type.  */
+  char buff_for_file_size[MAX_FILE_SIZE_STRING_LENGTH];
+  sprintf (buff_for_file_size, "%ld", file_size);
+
+  char *init_data = (char *) xcalloc (1, sizeof (char));
+  omnibor_append_to_string (&init_data, "blob ", strlen (init_data),
+			    strlen ("blob "));
+  omnibor_append_to_string (&init_data, buff_for_file_size, strlen (init_data),
+			    strlen (buff_for_file_size));
+  omnibor_append_to_string (&init_data, "\0", strlen (init_data), 1);
+
+  char *file_contents = (char *) xcalloc (file_size, sizeof (char));
+  fread (file_contents, 1, file_size, dependency_file);
+
+  /* Calculate the hash.  */
+  struct sha256_ctx ctx;
+
+  sha256_init_ctx (&ctx);
+
+  sha256_process_bytes (init_data, strlen (init_data) + 1, &ctx);
+  sha256_process_bytes (file_contents, file_size, &ctx);
+
+  sha256_finish_ctx (&ctx, resblock);
+
+  free (file_contents);
+  free (init_data);
+}
+
+/* Calculate the SHA256 gitoid using the given contents.  */
+
+static void
+calculate_sha256_omnibor_with_contents (char *contents,
+					unsigned char resblock[])
+{
+  long file_size = strlen (contents);
+
+  /* This length should be enough for everything up to 64B, which should
+     cover long type.  */
+  char buff_for_file_size[MAX_FILE_SIZE_STRING_LENGTH];
+  sprintf (buff_for_file_size, "%ld", file_size);
+
+  char *init_data = (char *) xcalloc (1, sizeof (char));
+  omnibor_append_to_string (&init_data, "blob ", strlen (init_data),
+			    strlen ("blob "));
+  omnibor_append_to_string (&init_data, buff_for_file_size, strlen (init_data),
+			    strlen (buff_for_file_size));
+  omnibor_append_to_string (&init_data, "\0", strlen (init_data), 1);
+
+  /* Calculate the hash.  */
+  struct sha256_ctx ctx;
+
+  sha256_init_ctx (&ctx);
+
+  sha256_process_bytes (init_data, strlen (init_data) + 1, &ctx);
+  sha256_process_bytes (contents, file_size, &ctx);
+
+  sha256_finish_ctx (&ctx, resblock);
+
+  free (init_data);
+}
+
+/* OmniBOR dependency file struct which contains its SHA1 gitoid, its SHA256
+   gitoid and its filename.  */
+
+struct omnibor_deps
+{
+  struct omnibor_deps *next;
+  char *sha1_contents;
+  char *sha256_contents;
+  char *name;
+};
+
+static struct omnibor_deps *omnibor_deps_head, *omnibor_deps_tail;
+
+static void
+omnibor_add_to_deps (char *filename, char *sha1_contents, char *sha256_contents,
+		     unsigned long sha1_contents_len,
+		     unsigned long sha256_contents_len)
+{
+  struct omnibor_deps *elem
+    = (struct omnibor_deps *) xmalloc (sizeof (*elem));
+  elem->name = (char *) xcalloc (1, sizeof (char));
+  omnibor_append_to_string (&elem->name, filename, strlen (elem->name),
+			    strlen (filename));
+  if (sha1_contents != NULL)
+    {
+      elem->sha1_contents = (char *) xcalloc (1, sizeof (char));
+      omnibor_append_to_string (&elem->sha1_contents, sha1_contents,
+				strlen (elem->sha1_contents),
+				sha1_contents_len);
+    }
+  else
+    elem->sha1_contents = NULL;
+  if (sha256_contents != NULL)
+    {
+      elem->sha256_contents = (char *) xcalloc (1, sizeof (char));
+      omnibor_append_to_string (&elem->sha256_contents, sha256_contents,
+				strlen (elem->sha256_contents),
+				sha256_contents_len);
+    }
+  else
+    elem->sha256_contents = NULL;
+  elem->next = NULL;
+  if (omnibor_deps_head == NULL)
+    omnibor_deps_head = elem;
+  else
+    omnibor_deps_tail->next = elem;
+  omnibor_deps_tail = elem;
+}
+
+void
+omnibor_clear_deps (void)
+{
+  struct omnibor_deps *dep = omnibor_deps_head, *old = NULL;
+  while (dep != NULL)
+    {
+      free (dep->name);
+      if (dep->sha1_contents)
+        free (dep->sha1_contents);
+      if (dep->sha256_contents)
+        free (dep->sha256_contents);
+      old = dep;
+      dep = dep->next;
+      free (old);
+    }
+
+  omnibor_deps_head = NULL;
+  omnibor_deps_tail = NULL;
+}
+
+static struct omnibor_deps *
+omnibor_is_dep_present (const char *name)
+{
+  struct omnibor_deps *dep;
+  for (dep = omnibor_deps_head; dep != NULL; dep = dep->next)
+    if (strcmp (name, dep->name) == 0)
+      return dep;
+
+  return NULL;
+}
+
+/* Sort the contents of the OmniBOR Document file using the selection sort
+   algorithm.  The parameter ind should be either 0 (sort the SHA1 OmniBOR
+   Document file) or 1 (sort the SHA256 OmniBOR Document file).  */
+
+static void
+omnibor_sort (unsigned int ind)
+{
+  if (omnibor_deps_head == NULL || omnibor_deps_head->next == NULL
+      || (ind != 0 && ind != 1))
+    return;
+
+  struct omnibor_deps *dep1, *dep2, *curr;
+  for (dep1 = omnibor_deps_head; dep1 != NULL; dep1 = dep1->next)
+    {
+      curr = dep1;
+      for (dep2 = dep1->next; dep2 != NULL; dep2 = dep2->next)
+        {
+          if ((dep1->sha1_contents == NULL && dep2->sha1_contents != NULL)
+               || (dep1->sha1_contents != NULL && dep2->sha1_contents == NULL)
+               || (dep1->sha256_contents == NULL && dep2->sha256_contents != NULL)
+               || (dep1->sha256_contents != NULL && dep2->sha256_contents == NULL))
+            return;
+          if ((ind == 0 && strcmp (curr->sha1_contents, dep2->sha1_contents) > 0)
+               || (ind == 1
+		   && strcmp (curr->sha256_contents, dep2->sha256_contents) > 0))
+            curr = dep2;
+        }
+
+      if (strcmp (curr->name, dep1->name) != 0)
+        {
+	  char *temp_name = (char *) xcalloc (1, sizeof (char));
+	  char *temp_sha1_contents = NULL;
+	  if (dep1->sha1_contents != NULL)
+	    temp_sha1_contents = (char *) xcalloc (1, sizeof (char));
+	  char *temp_sha256_contents = NULL;
+	  if (dep1->sha256_contents != NULL)
+	    temp_sha256_contents = (char *) xcalloc (1, sizeof (char));
+
+          omnibor_set_contents (&temp_name, dep1->name,
+				strlen (dep1->name));
+          if (dep1->sha1_contents != NULL)
+            omnibor_set_contents (&temp_sha1_contents, dep1->sha1_contents,
+				  2 * GITOID_LENGTH_SHA1);
+          if (dep1->sha256_contents != NULL)
+	    omnibor_set_contents (&temp_sha256_contents, dep1->sha256_contents,
+				  2 * GITOID_LENGTH_SHA256);
+
+          omnibor_set_contents (&dep1->name, curr->name,
+				strlen (curr->name));
+          if (dep1->sha1_contents != NULL)
+	    omnibor_set_contents (&dep1->sha1_contents, curr->sha1_contents,
+				  2 * GITOID_LENGTH_SHA1);
+          if (dep1->sha256_contents != NULL)
+	    omnibor_set_contents (&dep1->sha256_contents, curr->sha256_contents,
+				  2 * GITOID_LENGTH_SHA256);
+
+          omnibor_set_contents (&curr->name, temp_name,
+				strlen (temp_name));
+          if (dep1->sha1_contents != NULL)
+	    omnibor_set_contents (&curr->sha1_contents, temp_sha1_contents,
+				  2 * GITOID_LENGTH_SHA1);
+          if (dep1->sha256_contents != NULL)
+	    omnibor_set_contents (&curr->sha256_contents, temp_sha256_contents,
+				  2 * GITOID_LENGTH_SHA256);
+
+	  if (dep1->sha256_contents != NULL)
+	    free (temp_sha256_contents);
+	  if (dep1->sha1_contents != NULL)
+	    free (temp_sha1_contents);
+	  free (temp_name);
+        }
+    }
+}
+
+/* OmniBOR ".note.omnibor" section struct which contains the filename of the
+   dependency and the contents of its ".note.omnibor" section (the SHA1 gitoid
+   and the SHA256 gitoid).  */
+
+struct omnibor_note_sections
+{
+  struct omnibor_note_sections *next;
+  char *name;
+  char *sha1_contents;
+  char *sha256_contents;
+};
+
+struct omnibor_note_sections *omnibor_note_sections_head,
+			     *omnibor_note_sections_tail;
+
+void
+omnibor_add_to_note_sections (const char *filename, char *sha1_sec_contents,
+			      char *sha256_sec_contents,
+			      unsigned long sha1_sec_contents_len,
+			      unsigned long sha256_sec_contents_len)
+{
+  struct omnibor_note_sections *elem
+    = (struct omnibor_note_sections *) xmalloc (sizeof (*elem));
+  elem->name = (char *) xcalloc (1, sizeof (char));
+  omnibor_append_to_string (&elem->name, filename, strlen (elem->name),
+			    strlen (filename));
+  if (sha1_sec_contents != NULL)
+    {
+      elem->sha1_contents = (char *) xcalloc (1, sizeof (char));
+      omnibor_append_to_string (&elem->sha1_contents, sha1_sec_contents,
+				strlen (elem->sha1_contents),
+				sha1_sec_contents_len);
+    }
+  else
+    elem->sha1_contents = NULL;
+  if (sha256_sec_contents != NULL)
+    {
+      elem->sha256_contents = (char *) xcalloc (1, sizeof (char));
+      omnibor_append_to_string (&elem->sha256_contents, sha256_sec_contents,
+				strlen (elem->sha256_contents),
+				sha256_sec_contents_len);
+    }
+  else
+    elem->sha256_contents = NULL;
+  elem->next = NULL;
+  if (omnibor_note_sections_head == NULL)
+    omnibor_note_sections_head = elem;
+  else
+    omnibor_note_sections_tail->next = elem;
+  omnibor_note_sections_tail = elem;
+}
+
+void
+omnibor_clear_note_sections (void)
+{
+  struct omnibor_note_sections *dep = omnibor_note_sections_head, *old = NULL;
+  while (dep != NULL)
+    {
+      free (dep->name);
+      if (dep->sha1_contents)
+        free (dep->sha1_contents);
+      if (dep->sha256_contents)
+        free (dep->sha256_contents);
+      old = dep;
+      dep = dep->next;
+      free (old);
+    }
+
+  omnibor_note_sections_head = NULL;
+  omnibor_note_sections_tail = NULL;
+}
+
+/* If the dependency with the given name is not in the omnibor_note_sections_head
+   list, return NULL.  Otherwise, return the SHA1 gitoid (hash_func_type == 0)
+   or the SHA256 gitoid (hash_func_type == 1) for that dependency.  If any value
+   other than 0 or 1 is passed in hash_func_type, the behaviour is undefined.  */
+
+static char *
+omnibor_is_note_section_present (const char *name, unsigned hash_func_type)
+{
+  struct omnibor_note_sections *note;
+  for (note = omnibor_note_sections_head; note != NULL; note = note->next)
+    if (strcmp (name, note->name) == 0)
+      {
+        if (hash_func_type == 0)
+          return note->sha1_contents;
+        else if (hash_func_type == 1)
+          return note->sha256_contents;
+        /* This point should never be reached.  */
+        else
+          return NULL;
+      }
+
+  return NULL;
+}
+
+/* Store the OmniBOR information in the specified directory whose path is
+   written in the result_dir parameter.  If result_dir is NULL or an empty
+   string, the OmniBOR information is stored in the current working directory.
+   The hash_size parameter has to be either GITOID_LENGTH_SHA1 (for the SHA1
+   OmniBOR information) or GITOID_LENGTH_SHA256 (for the SHA256 OmniBOR
+   information).  */
+
+static void
+create_omnibor_document_file (char **name, const char *result_dir,
+			      char *new_file_contents, unsigned int new_file_size,
+			      unsigned int hash_size)
+{
+  if (hash_size != GITOID_LENGTH_SHA1 && hash_size != GITOID_LENGTH_SHA256)
+    return;
+
+  char *path_objects = (char *) xcalloc (1, sizeof (char));
+  omnibor_append_to_string (&path_objects, "objects", strlen (path_objects),
+			    strlen ("objects"));
+  DIR *dir_one = NULL;
+
+  if (result_dir)
+    {
+      if ((dir_one = opendir (result_dir)) == NULL)
+        {
+          mkdir (result_dir, S_IRWXU);
+	  dir_one = opendir (result_dir);
+	}
+
+      if (dir_one != NULL)
+        {
+          omnibor_add_prefix_to_string (&path_objects, "/");
+          omnibor_add_prefix_to_string (&path_objects, result_dir);
+          int dfd1 = dirfd (dir_one);
+          mkdirat (dfd1, "objects", S_IRWXU);
+        }
+      else if (strlen (result_dir) != 0)
+        {
+          DIR *final_dir = open_all_directories_in_path (result_dir);
+          /* If an error occurred, illegal path is detected and the OmniBOR
+             information is not written.  */
+          /* TODO: Maybe put a message here that a specified path, in which
+	     the OmniBOR information should be stored, is illegal.  */
+          if (final_dir == NULL)
+            {
+              close_all_directories_in_path ();
+              free (path_objects);
+              omnibor_set_contents (name, "", 0);
+              return;
+            }
+          else
+            {
+              omnibor_add_prefix_to_string (&path_objects, "/");
+	      omnibor_add_prefix_to_string (&path_objects, result_dir);
+              int dfd1 = dirfd (final_dir);
+              mkdirat (dfd1, "objects", S_IRWXU);
+            }
+        }
+      else
+        mkdir ("objects", S_IRWXU);
+    }
+  /* Put the OmniBOR Document file in the current working directory.  */
+  else
+    mkdir ("objects", S_IRWXU);
+
+  DIR *dir_two = opendir (path_objects);
+  if (dir_two == NULL)
+    {
+      close_all_directories_in_path ();
+      if (result_dir && dir_one)
+        closedir (dir_one);
+      free (path_objects);
+      omnibor_set_contents (name, "", 0);
+      return;
+    }
+
+  int dfd2 = dirfd (dir_two);
+
+  char *path_sha = NULL;
+  DIR *dir_three = NULL;
+  if (hash_size == GITOID_LENGTH_SHA1)
+    {
+      mkdirat (dfd2, "gitoid_blob_sha1", S_IRWXU);
+
+      path_sha = (char *) xcalloc (1, sizeof (char));
+      omnibor_append_to_string (&path_sha, path_objects, strlen (path_sha),
+				strlen (path_objects));
+      omnibor_append_to_string (&path_sha, "/gitoid_blob_sha1",
+				strlen (path_sha),
+				strlen ("/gitoid_blob_sha1"));
+      dir_three = opendir (path_sha);
+      if (dir_three == NULL)
+        {
+          closedir (dir_two);
+          close_all_directories_in_path ();
+          if (result_dir && dir_one)
+            closedir (dir_one);
+          free (path_sha);
+          free (path_objects);
+          omnibor_set_contents (name, "", 0);
+          return;
+        }
+    }
+  else
+    {
+      mkdirat (dfd2, "gitoid_blob_sha256", S_IRWXU);
+
+      path_sha = (char *) xcalloc (1, sizeof (char));
+      omnibor_append_to_string (&path_sha, path_objects, strlen (path_sha),
+				strlen (path_objects));
+      omnibor_append_to_string (&path_sha, "/gitoid_blob_sha256",
+				strlen (path_sha),
+				strlen ("/gitoid_blob_sha256"));
+      dir_three = opendir (path_sha);
+      if (dir_three == NULL)
+        {
+          closedir (dir_two);
+          close_all_directories_in_path ();
+          if (result_dir && dir_one)
+            closedir (dir_one);
+          free (path_sha);
+          free (path_objects);
+          omnibor_set_contents (name, "", 0);
+          return;
+        }
+    }
+
+  int dfd3 = dirfd (dir_three);
+  char *name_substr = (char *) xcalloc (1, sizeof (char));
+  omnibor_substr (&name_substr, 0, 2, *name);
+  mkdirat (dfd3, name_substr, S_IRWXU);
+
+  char *path_dir = (char *) xcalloc (1, sizeof (char));
+  omnibor_append_to_string (&path_dir, path_sha, strlen (path_dir),
+			    strlen (path_sha));
+  omnibor_append_to_string (&path_dir, "/", strlen (path_dir),
+			    strlen ("/"));
+
+  /* Save current length of path_dir before characters from hash are added to
+     the path.  This is done because the calculation of the length of the path
+     from here moving forward is done manually by adding the length of the
+     following parts of the path since hash can produce '\0' characters, so
+     strlen is not good enough.  */
+  unsigned long path_dir_temp_len = strlen (path_dir);
+
+  omnibor_append_to_string (&path_dir, name_substr, path_dir_temp_len, 2);
+  DIR *dir_four = opendir (path_dir);
+  if (dir_four == NULL)
+    {
+      closedir (dir_three);
+      closedir (dir_two);
+      close_all_directories_in_path ();
+      if (result_dir && dir_one)
+        closedir (dir_one);
+      free (path_dir);
+      free (name_substr);
+      free (path_sha);
+      free (path_objects);
+      omnibor_set_contents (name, "", 0);
+      return;
+    }
+
+  char *new_file_path = (char *) xcalloc (1, sizeof (char));
+  omnibor_substr (&name_substr, 2, 2 * hash_size - 2, *name);
+  omnibor_append_to_string (&new_file_path, path_dir, strlen (new_file_path),
+			    path_dir_temp_len + 2);
+  omnibor_append_to_string (&new_file_path, "/", path_dir_temp_len + 2,
+			    strlen ("/"));
+  omnibor_append_to_string (&new_file_path, name_substr,
+			    path_dir_temp_len + 2 + strlen ("/"),
+			    2 * hash_size - 2);
+
+  FILE *new_file = fopen (new_file_path, "w");
+
+  fwrite (new_file_contents, sizeof (char), new_file_size, new_file);
+
+  fclose (new_file);
+  closedir (dir_four);
+  closedir (dir_three);
+  closedir (dir_two);
+  close_all_directories_in_path ();
+  if (result_dir && dir_one)
+    closedir (dir_one);
+  free (new_file_path);
+  free (path_dir);
+  free (name_substr);
+  free (path_sha);
+  free (path_objects);
+}
+
+/* Calculate the gitoids of all the dependencies of the resulting object file
+   and create the OmniBOR Document file using them.  Then calculate the
+   gitoid of that file and name it with that gitoid in the format specified
+   by the OmniBOR specification.  Use SHA1 hashing algorithm for calculating
+   all the gitoids.  */
+
+void
+write_sha1_omnibor (char **name, const char *result_dir)
+{
+  static const char *const lut = "0123456789abcdef";
+  char *new_file_contents = (char *) xcalloc (1, sizeof (char));
+  omnibor_append_to_string (&new_file_contents, "gitoid:blob:sha1\n",
+			    strlen (new_file_contents),
+			    strlen ("gitoid:blob:sha1\n"));
+  char *temp_file_contents = (char *) xcalloc (1, sizeof (char));
+  char *high_ch = (char *) xmalloc (sizeof (char) * 2);
+  high_ch[1] = '\0';
+  char *low_ch = (char *) xmalloc (sizeof (char) * 2);
+  low_ch[1] = '\0';
+
+  struct omnibor_deps *curr_dep = NULL;
+  struct dependency *dep;
+  for (dep = dep_chain; dep != NULL; dep = dep->next)
+    {
+      if ((curr_dep = omnibor_is_dep_present (dep->file)) != NULL)
+	if (curr_dep->sha1_contents != NULL)
+	  continue;
+
+      FILE *dep_file_handle = fopen (dep->file, "rb");
+      unsigned char resblock[GITOID_LENGTH_SHA1];
+
+      calculate_sha1_omnibor (dep_file_handle, resblock);
+
+      fclose (dep_file_handle);
+
+      omnibor_set_contents (&temp_file_contents, "", 0);
+
+      for (unsigned i = 0; i != GITOID_LENGTH_SHA1; i++)
+        {
+          high_ch[0] = lut[resblock[i] >> 4];
+          low_ch[0] = lut[resblock[i] & 15];
+          omnibor_append_to_string (&temp_file_contents, high_ch,
+				    i * 2, 2);
+          omnibor_append_to_string (&temp_file_contents, low_ch,
+				    i * 2 + 1, 2);
+        }
+
+      if (curr_dep == NULL)
+        omnibor_add_to_deps (dep->file, temp_file_contents, NULL,
+			     2 * GITOID_LENGTH_SHA1, 0);
+      /* Here curr_dep->sha1_contents has to be NULL.  */
+      else
+        {
+          curr_dep->sha1_contents = (char *) xcalloc (1, sizeof (char));
+	  omnibor_append_to_string (&curr_dep->sha1_contents,
+				    temp_file_contents,
+				    strlen (curr_dep->sha1_contents),
+				    2 * GITOID_LENGTH_SHA1);
+        }
+    }
+
+  omnibor_sort (0);
+
+  unsigned current_length = strlen (new_file_contents);
+  struct omnibor_deps *dependency_file;
+  for (dependency_file = omnibor_deps_head; dependency_file != NULL;
+       dependency_file = dependency_file->next)
+    {
+      omnibor_append_to_string (&new_file_contents, "blob ",
+				current_length,
+				strlen ("blob "));
+      current_length += strlen ("blob ");
+      omnibor_append_to_string (&new_file_contents, dependency_file->sha1_contents,
+				current_length,
+				2 * GITOID_LENGTH_SHA1);
+      current_length += 2 * GITOID_LENGTH_SHA1;
+      char *note_sec_contents =
+		omnibor_is_note_section_present (dependency_file->name, 0);
+      if (note_sec_contents != NULL)
+        {
+          omnibor_append_to_string (&new_file_contents, " bom ",
+				    current_length,
+				    strlen (" bom "));
+          current_length += strlen (" bom ");
+	  omnibor_append_to_string (&new_file_contents, note_sec_contents,
+				    current_length,
+				    2 * GITOID_LENGTH_SHA1);
+          current_length += 2 * GITOID_LENGTH_SHA1;
+        }
+      omnibor_append_to_string (&new_file_contents, "\n",
+				current_length,
+				strlen ("\n"));
+      current_length += strlen ("\n");
+    }
+  unsigned new_file_size = current_length;
+
+  unsigned char resblock[GITOID_LENGTH_SHA1];
+  calculate_sha1_omnibor_with_contents (new_file_contents, resblock);
+
+  for (unsigned i = 0; i != GITOID_LENGTH_SHA1; i++)
+    {
+      high_ch[0] = lut[resblock[i] >> 4];
+      low_ch[0] = lut[resblock[i] & 15];
+      omnibor_append_to_string (name, high_ch, i * 2, 2);
+      omnibor_append_to_string (name, low_ch, i * 2 + 1, 2);
+    }
+  free (low_ch);
+  free (high_ch);
+
+  create_omnibor_document_file (name, result_dir, new_file_contents,
+				new_file_size, GITOID_LENGTH_SHA1);
+
+  free (temp_file_contents);
+  free (new_file_contents);
+}
+
+/* Calculate the gitoids of all the dependencies of the resulting object file
+   and create the OmniBOR Document file using them.  Then calculate the
+   gitoid of that file and name it with that gitoid in the format specified
+   by the OmniBOR specification.  Use SHA256 hashing algorithm for calculating
+   all the gitoids.  */
+
+void
+write_sha256_omnibor (char **name, const char *result_dir)
+{
+  static const char *const lut = "0123456789abcdef";
+  char *new_file_contents = (char *) xcalloc (1, sizeof (char));
+  omnibor_append_to_string (&new_file_contents, "gitoid:blob:sha256\n",
+			    strlen (new_file_contents),
+			    strlen ("gitoid:blob:sha256\n"));
+  char *temp_file_contents = (char *) xcalloc (1, sizeof (char));
+  char *high_ch = (char *) xmalloc (sizeof (char) * 2);
+  high_ch[1] = '\0';
+  char *low_ch = (char *) xmalloc (sizeof (char) * 2);
+  low_ch[1] = '\0';
+
+  struct omnibor_deps *curr_dep = NULL;
+  struct dependency *dep;
+  for (dep = dep_chain; dep != NULL; dep = dep->next)
+    {
+      if ((curr_dep = omnibor_is_dep_present (dep->file)) != NULL)
+	if (curr_dep->sha256_contents != NULL)
+	  continue;
+
+      FILE *dep_file_handle = fopen (dep->file, "rb");
+      unsigned char resblock[GITOID_LENGTH_SHA256];
+
+      calculate_sha256_omnibor (dep_file_handle, resblock);
+
+      fclose (dep_file_handle);
+
+      omnibor_set_contents (&temp_file_contents, "", 0);
+
+      for (unsigned i = 0; i != GITOID_LENGTH_SHA256; i++)
+        {
+          high_ch[0] = lut[resblock[i] >> 4];
+          low_ch[0] = lut[resblock[i] & 15];
+          omnibor_append_to_string (&temp_file_contents, high_ch,
+				    i * 2, 2);
+          omnibor_append_to_string (&temp_file_contents, low_ch,
+				    i * 2 + 1, 2);
+        }
+
+      if (curr_dep == NULL)
+        omnibor_add_to_deps (dep->file, NULL, temp_file_contents,
+			     0, 2 * GITOID_LENGTH_SHA256);
+      /* Here curr_dep->sha256_contents has to be NULL.  */
+      else
+        {
+          curr_dep->sha256_contents = (char *) xcalloc (1, sizeof (char));
+	  omnibor_append_to_string (&curr_dep->sha256_contents,
+				    temp_file_contents,
+				    strlen (curr_dep->sha256_contents),
+				    2 * GITOID_LENGTH_SHA256);
+        }
+    }
+
+  omnibor_sort (1);
+
+  unsigned current_length = strlen (new_file_contents);
+  struct omnibor_deps *dependency_file;
+  for (dependency_file = omnibor_deps_head; dependency_file != NULL;
+       dependency_file = dependency_file->next)
+    {
+      omnibor_append_to_string (&new_file_contents, "blob ",
+				current_length,
+				strlen ("blob "));
+      current_length += strlen ("blob ");
+      omnibor_append_to_string (&new_file_contents, dependency_file->sha256_contents,
+				current_length,
+				2 * GITOID_LENGTH_SHA256);
+      current_length += 2 * GITOID_LENGTH_SHA256;
+      char *note_sec_contents =
+		omnibor_is_note_section_present (dependency_file->name, 1);
+      if (note_sec_contents != NULL)
+        {
+          omnibor_append_to_string (&new_file_contents, " bom ",
+				    current_length,
+				    strlen (" bom "));
+          current_length += strlen (" bom ");
+	  omnibor_append_to_string (&new_file_contents, note_sec_contents,
+				    current_length,
+				    2 * GITOID_LENGTH_SHA256);
+          current_length += 2 * GITOID_LENGTH_SHA256;
+        }
+      omnibor_append_to_string (&new_file_contents, "\n",
+				current_length,
+				strlen ("\n"));
+      current_length += strlen ("\n");
+    }
+  unsigned new_file_size = current_length;
+
+  unsigned char resblock[GITOID_LENGTH_SHA256];
+  calculate_sha256_omnibor_with_contents (new_file_contents, resblock);
+
+  for (unsigned i = 0; i != GITOID_LENGTH_SHA256; i++)
+    {
+      high_ch[0] = lut[resblock[i] >> 4];
+      low_ch[0] = lut[resblock[i] & 15];
+      omnibor_append_to_string (name, high_ch, i * 2, 2);
+      omnibor_append_to_string (name, low_ch, i * 2 + 1, 2);
+    }
+  free (low_ch);
+  free (high_ch);
+
+  create_omnibor_document_file (name, result_dir, new_file_contents,
+				new_file_size, GITOID_LENGTH_SHA256);
+
+  free (temp_file_contents);
+  free (new_file_contents);
+}
+
+/* Create the symlink for the SHA1 OmniBOR Document file.  */
+
+void
+create_sha1_symlink (const char *gitoid_sha1, char *res_dir)
+{
+  static const char *const lut = "0123456789abcdef";
+  char *gitoid_obj_sha1 = (char *) xcalloc (1, sizeof (char));
+  char *high_ch = (char *) xmalloc (sizeof (char) * 2);
+  high_ch[1] = '\0';
+  char *low_ch = (char *) xmalloc (sizeof (char) * 2);
+  low_ch[1] = '\0';
+
+  FILE *object_file = fopen (out_file_name, "rb");
+  unsigned char resblock[GITOID_LENGTH_SHA1];
+
+  calculate_sha1_omnibor (object_file, resblock);
+
+  fclose (object_file);
+
+  for (unsigned i = 0; i != GITOID_LENGTH_SHA1; i++)
+    {
+      high_ch[0] = lut[resblock[i] >> 4];
+      low_ch[0] = lut[resblock[i] & 15];
+      omnibor_append_to_string (&gitoid_obj_sha1, high_ch, i * 2, 2);
+      omnibor_append_to_string (&gitoid_obj_sha1, low_ch, i * 2 + 1, 2);
+    }
+
+  char *path_adg = (char *) xcalloc (1, sizeof (char));
+  DIR *dir = NULL, *dir_adg = NULL;
+
+  if (strcmp ("", res_dir) != 0)
+    {
+      dir = opendir (res_dir);
+      if (dir == NULL)
+        {
+          free (path_adg);
+          free (low_ch);
+          free (high_ch);
+          free (gitoid_obj_sha1);
+          return;
+        }
+
+      int dfd = dirfd (dir);
+      mkdirat (dfd, ".adg", S_IRWXU);
+      omnibor_append_to_string (&path_adg, res_dir, strlen (path_adg),
+				strlen (res_dir));
+      omnibor_append_to_string (&path_adg, "/.adg", strlen (path_adg),
+				strlen ("/.adg"));
+    }
+  else
+    {
+      mkdir (".adg", S_IRWXU);
+      omnibor_append_to_string (&path_adg, res_dir, strlen (path_adg),
+				strlen (res_dir));
+      omnibor_append_to_string (&path_adg, ".adg", strlen (path_adg),
+				strlen (".adg"));
+    }
+
+  dir_adg = opendir (path_adg);
+  if (dir_adg == NULL)
+    {
+      if (strcmp ("", res_dir) != 0)
+        closedir (dir);
+      free (path_adg);
+      free (low_ch);
+      free (high_ch);
+      free (gitoid_obj_sha1);
+      return;
+    }
+
+  int dfd_adg = dirfd (dir_adg);
+  symlinkat (gitoid_sha1, dfd_adg, gitoid_obj_sha1);
+
+  closedir (dir_adg);
+  if (strcmp ("", res_dir) != 0)
+    closedir (dir);
+  free (path_adg);
+  free (low_ch);
+  free (high_ch);
+  free (gitoid_obj_sha1);
+}
+
+/* Create the symlink for the SHA256 OmniBOR Document file.  */
+
+void
+create_sha256_symlink (const char *gitoid_sha256, char *res_dir)
+{
+  static const char *const lut = "0123456789abcdef";
+  char *gitoid_obj_sha256 = (char *) xcalloc (1, sizeof (char));
+  char *high_ch = (char *) xmalloc (sizeof (char) * 2);
+  high_ch[1] = '\0';
+  char *low_ch = (char *) xmalloc (sizeof (char) * 2);
+  low_ch[1] = '\0';
+
+  FILE *object_file = fopen (out_file_name, "rb");
+  unsigned char resblock[GITOID_LENGTH_SHA256];
+
+  calculate_sha256_omnibor (object_file, resblock);
+
+  fclose (object_file);
+
+  for (unsigned i = 0; i != GITOID_LENGTH_SHA256; i++)
+    {
+      high_ch[0] = lut[resblock[i] >> 4];
+      low_ch[0] = lut[resblock[i] & 15];
+      omnibor_append_to_string (&gitoid_obj_sha256, high_ch, i * 2, 2);
+      omnibor_append_to_string (&gitoid_obj_sha256, low_ch, i * 2 + 1, 2);
+    }
+
+  char *path_adg = (char *) xcalloc (1, sizeof (char));
+  DIR *dir = NULL, *dir_adg = NULL;
+
+  if (strcmp ("", res_dir) != 0)
+    {
+      dir = opendir (res_dir);
+      if (dir == NULL)
+        {
+          free (path_adg);
+          free (low_ch);
+          free (high_ch);
+          free (gitoid_obj_sha256);
+          return;
+        }
+
+      int dfd = dirfd (dir);
+      mkdirat (dfd, ".adg", S_IRWXU);
+      omnibor_append_to_string (&path_adg, res_dir, strlen (path_adg),
+				strlen (res_dir));
+      omnibor_append_to_string (&path_adg, "/.adg", strlen (path_adg),
+				strlen ("/.adg"));
+    }
+  else
+    {
+      mkdir (".adg", S_IRWXU);
+      omnibor_append_to_string (&path_adg, res_dir, strlen (path_adg),
+				strlen (res_dir));
+      omnibor_append_to_string (&path_adg, ".adg", strlen (path_adg),
+				strlen (".adg"));
+    }
+
+  dir_adg = opendir (path_adg);
+  if (dir_adg == NULL)
+    {
+      if (strcmp ("", res_dir) != 0)
+        closedir (dir);
+      free (path_adg);
+      free (low_ch);
+      free (high_ch);
+      free (gitoid_obj_sha256);
+      return;
+    }
+
+  int dfd_adg = dirfd (dir_adg);
+  symlinkat (gitoid_sha256, dfd_adg, gitoid_obj_sha256);
+
+  closedir (dir_adg);
+  if (strcmp ("", res_dir) != 0)
+    closedir (dir);
+  free (path_adg);
+  free (low_ch);
+  free (high_ch);
+  free (gitoid_obj_sha256);
 }

--- a/binutils-2.39/gas/doc/as.texi
+++ b/binutils-2.39/gas/doc/as.texi
@@ -2381,6 +2381,7 @@ assembler.)
 * MD::            --MD for dependency tracking
 * no-pad-sections:: --no-pad-sections to stop section padding
 * o::             -o to name the object file
+* omnibor::	  --omnibor for OmniBOR calculation
 * R::             -R to join data and text sections
 * statistics::    --statistics to see statistics about assembly
 * traditional-format:: --traditional-format for compatible output
@@ -2714,6 +2715,17 @@ object file a different name.
 
 Whatever the object file is called, @command{@value{AS}} overwrites any
 existing file of the same name.
+
+@node omnibor
+@section OmniBOR calculation: @option{--omnibor}
+
+@kindex --omnibor
+@cindex OmniBOR calculation
+
+This option enables the calculation of the OmniBOR information, the generation
+of the OmniBOR Document files for the object file output and the embedding of
+the gitoids of those OmniBOR Document files into the @samp{.note.omnibor} section
+of that object file.
 
 @node R
 @section Join Data and Text Sections: @option{-R}

--- a/binutils-2.39/gas/read.c
+++ b/binutils-2.39/gas/read.c
@@ -852,6 +852,8 @@ read_a_source_file (const char *name)
   long temp;
   const pseudo_typeS *pop;
 
+  omnibor_input_filename = name;
+
 #ifdef WARN_COMMENTS
   found_comment = 0;
 #endif

--- a/binutils-2.39/gas/testsuite/gas/elf/omnibor.d
+++ b/binutils-2.39/gas/testsuite/gas/elf/omnibor.d
@@ -1,0 +1,11 @@
+#source: omnibor.s
+#readelf: -x .note.omnibor
+
+Hex dump of section '.note.omnibor':
+  [x0-9]+ 08000000 14000000 01000000 4f4d4e49 ............OMNI
+  [x0-9]+ 424f5200 fe2bd8f7 4815e578 a2eed695 BOR..\+..H..x....
+  [x0-9]+ 357239e5 4fe88848 08000000 20000000 5r9.O..H.... ...
+  [x0-9]+ 02000000 4f4d4e49 424f5200 58fc9822 ....OMNIBOR.X.."
+  [x0-9]+ 59aecdb0 7634390a 8b4ba1ac 3024c40a Y...v49..K..0\$..
+  [x0-9]+ c1f2770a 17451c87 cf2e313c          ..w..E....1<
+

--- a/binutils-2.39/gas/testsuite/gas/elf/omnibor.exp
+++ b/binutils-2.39/gas/testsuite/gas/elf/omnibor.exp
@@ -1,0 +1,94 @@
+# Expect script for OmniBOR calculation tests.
+#   Copyright (C) 2021-2022 Free Software Foundation, Inc.
+#
+# This file is part of the GNU Binutils.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston,
+# MA 02110-1301, USA.
+#
+
+proc check_omnibor_document_contents_sha1 { omnibor_file test_name } {
+    if [file exists $omnibor_file] then {
+        set file_a [open $omnibor_file r]
+    } else {
+        perror "$omnibor_file doesn't exist"
+    }
+
+    set eof -1
+    set list_a {}
+
+    while { [gets $file_a line] != $eof } {
+        lappend list_a $line
+    }
+    close $file_a
+
+    if { [regexp "^gitoid:blob:sha1 {blob 471936a545bb9506db52fa9ff0e03ad8b7d83771 bom 0206a0b4d17c08ed01b57a37c27b81b154f1aa23}$" $list_a] } then {
+        pass $test_name
+    } else {
+        perror "$list_a"
+        fail $test_name
+    }
+    return 0
+}
+
+proc check_omnibor_document_contents_sha256 { omnibor_file test_name } {
+    if [file exists $omnibor_file] then {
+        set file_a [open $omnibor_file r]
+    } else {
+        perror "$omnibor_file doesn't exist"
+    }
+
+    set eof -1
+    set list_a {}
+
+    while { [gets $file_a line] != $eof } {
+        lappend list_a $line
+    }
+    close $file_a
+
+    if { [regexp "^gitoid:blob:sha256 {blob 3eb368b9b7aea36e2c0270e0a760c6c41f2ff8387620369dc9f81f2c31f0e931 bom 3bc2f893cab66e0230a3410b23f9e804b6984a7c392ee3e9735e092dacb3d9a8}$" $list_a] } then {
+        pass $test_name
+    } else {
+        perror "$list_a"
+        fail $test_name
+    }
+    return 0
+}
+
+set env(OMNIBOR_DIR) "env_dir"
+
+run_dump_test "omnibor" [list [list as --omnibor] [list warning ".*"]]
+run_dump_test "omnibor" [list [list as --omnibor=dir] [list warning ".*"]]
+run_dump_test "omnibor" [list [list warning ".*"]]
+
+check_omnibor_document_contents_sha1 "env_dir/objects/gitoid_blob_sha1/fe/2bd8f74815e578a2eed695357239e54fe88848" "OmniBOR SHA1 Document file contents 1"
+
+check_omnibor_document_contents_sha256 "env_dir/objects/gitoid_blob_sha256/58/fc982259aecdb07634390a8b4ba1ac3024c40ac1f2770a17451c87cf2e313c" "OmniBOR SHA256 Document file contents 1"
+
+unset env(OMNIBOR_DIR)
+
+run_dump_test "omnibor" [list [list as --omnibor] [list warning ".*"]]
+
+# OmniBOR information is stored in tmpdir because the resulting object file is stored there
+check_omnibor_document_contents_sha1 "tmpdir/objects/gitoid_blob_sha1/fe/2bd8f74815e578a2eed695357239e54fe88848" "OmniBOR SHA1 Document file contents 2"
+
+# OmniBOR information is stored in tmpdir because the resulting object file is stored there
+check_omnibor_document_contents_sha256 "tmpdir/objects/gitoid_blob_sha256/58/fc982259aecdb07634390a8b4ba1ac3024c40ac1f2770a17451c87cf2e313c" "OmniBOR SHA256 Document file contents 2"
+
+run_dump_test "omnibor" [list [list as --omnibor=dir] [list warning ".*"]]
+
+check_omnibor_document_contents_sha1 "dir/objects/gitoid_blob_sha1/fe/2bd8f74815e578a2eed695357239e54fe88848" "OmniBOR SHA1 Document file contents 3"
+
+check_omnibor_document_contents_sha256 "dir/objects/gitoid_blob_sha256/58/fc982259aecdb07634390a8b4ba1ac3024c40ac1f2770a17451c87cf2e313c" "OmniBOR SHA256 Document file contents 3"

--- a/binutils-2.39/gas/testsuite/gas/elf/omnibor.s
+++ b/binutils-2.39/gas/testsuite/gas/elf/omnibor.s
@@ -1,0 +1,60 @@
+        .section	.note.omnibor,"awMS",@progbits,1
+	.text
+	.data
+	.align 8
+	.type	a, @object
+	.size	a, 8
+a:
+	.quad	10
+	.section	.rodata
+.LC0:
+	.string	"Got%ld!\n"
+	.text
+	.globl	main
+	.type	main, @function
+main:
+.LFB0:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	movq	a(%rip), %rax
+	movq	%rax, %rsi
+	movl	$.LC0, %edi
+	movl	$0, %eax
+	call	printf
+	movl	$0, %eax
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE0:
+	.size	main, .-main
+	.ident	"GCC: (GNU) 11.3.0"
+	.section	.note.GNU-stack,"",@progbits
+	.section	.note.omnibor
+	.string	"\b"
+	.string	""
+	.string	""
+	.string	"\024"
+	.string	""
+	.string	""
+	.string	"\001"
+	.string	""
+	.string	""
+	.string	"OMNIBOR"
+	.ascii	"\002\006\240\264\321|\b\355\001\265z7\302{\201\261T\361\252#"
+	.string	"\b"
+	.string	""
+	.string	""
+	.string	" "
+	.string	""
+	.string	""
+	.string	"\002"
+	.string	""
+	.string	""
+	.string	"OMNIBOR"
+	.ascii	";\302\370\223\312\266n\0020\243A\013#\371\350\004\266\230J|9"
+	.ascii	".\343\351s^\t-\254\263\331\250"


### PR DESCRIPTION
This PR adds the implementation of the OmniBOR concept in the as assembler tool.
It includes:
          1) The addition of a new --omnibor=<optional_dir> assembler option which enables the OmniBOR calculation.
          2) The creation of the SHA1 and SHA256 OmniBOR Document files in the desired directory in the specified format (see the OmniBOR specification), when OmniBOR calculation is enabled.
          3) The creation of the ELF NOTE .note.omnibor section in the resulting object file which contains the OmniBOR Document files' gitoids, when OmniBOR calculation is enabled.
          4) The possibility of specifying the directory in which the OmniBOR Document files will be stored (OMNIBOR_DIR environment variable, --omnibor=<dir>, or the default case which is the --omnibor option).
          5) The ability to parse the OmniBOR information (SHA1 and SHA256 gitoids) from the .note.omnibor section in the input assembly file (provided that it has any) and then put that information as the 'bom' part of the OmniBOR Document files' entry for the input assembly file dependency, when OmniBOR calculation is enabled.
          6) The support for creating both SHA1 and SHA256 OmniBOR symlinks in a format: (gitoid_of_resulting_object_file -> gitoid_of_omnibor_doc_file) in the .adg directory which is created in the same directory where OmniBOR information top-level directory is stored.
          7) The tests which cover the OmniBOR implementation.