### PR TITLE
Updating the OmniBOR implementation in GNU as tool

### DIFF
--- a/binutils-2.39/gas/as.h
+++ b/binutils-2.39/gas/as.h
@@ -509,6 +509,7 @@ void create_sha256_symlink (const char *, char *);
 void write_omnibor (const char *, const char *);
 
 /* OmniBOR-related variable declarations.  Defined in as.c.  */
+extern bool omnibor_input_file_is_temporary;
 extern const char *omnibor_dir;
 extern const char *omnibor_input_filename;
 

--- a/binutils-2.39/gas/doc/as.texi
+++ b/binutils-2.39/gas/doc/as.texi
@@ -2382,6 +2382,7 @@ assembler.)
 * no-pad-sections:: --no-pad-sections to stop section padding
 * o::             -o to name the object file
 * omnibor::	  --omnibor for OmniBOR calculation
+* omnibor-tempfile:: --omnibor-tempfile to specify that the input file is temporary
 * R::             -R to join data and text sections
 * statistics::    --statistics to see statistics about assembly
 * traditional-format:: --traditional-format for compatible output
@@ -2726,6 +2727,18 @@ This option enables the calculation of the OmniBOR information, the generation
 of the OmniBOR Document files for the object file output and the embedding of
 the gitoids of those OmniBOR Document files into the @samp{.note.omnibor} section
 of that object file.
+
+@node omnibor-tempfile
+@section Specify that the assembler input is temporary: @option{--omnibor-tempfile}
+
+@kindex --omnibor-tempfile
+@cindex Specify that the assembler input is temporary
+
+This option tells the assembler that its input is temporary, which is useful
+information when analyzing the OmniBOR information in the input and when
+calculating the OmniBOR information by the assembler.  If this option is not set,
+assembler considers that its input is existing.  This option can be used outside
+the OmniBOR concept, but it is not recommended.
 
 @node R
 @section Join Data and Text Sections: @option{-R}


### PR DESCRIPTION
This PR introduces the changes to the OmniBOR implementation in the GNU as tool. The assembler should now behave in the OmniBOR context as follows:
          1. If assembler's input file is existing and it contains the OmniBOR information, then:
                    if the OmniBOR calculation is enabled, it calculates the new OmniBOR information, extracts the OmniBOR information from input and puts it in the 'bom' part of the dependency corresponding to the input in the new OmniBOR Document files, otherwise removes any OmniBOR information.
          2. If assembler's input file is existing and it doesn't contain the OmniBOR information, then:
                    if the OmniBOR calculation is enabled, it calculates the OmniBOR information regularly.
          3. If assembler's input file is temporary and it contains the OmniBOR information, then:
                    it just carries the OmniBOR information found in the input file, regardless of whether the OmniBOR calculation is enabled in the assembler or not.
          4. If assembler's input file is temporary and it doesn't contain the OmniBOR information, then:
                    if the OmniBOR calculation is enabled, it calculates the OmniBOR information regularly.

Also, a new option '--omnibor-tempfile' is added, which is used to indicate whether the input to the assembler is a temporary file. It should be passed to the assembler by GCC and that is recommended, but not restricted.