### PR TITLE
Adding changes to specification of the directory OmniBOR information should be stored in

### DIFF
--- a/binutils-2.39/gas/as.h
+++ b/binutils-2.39/gas/as.h
@@ -499,7 +499,6 @@ void omnibor_add_to_note_sections (const char *, char *, char *,
 				   unsigned long, unsigned long);
 void omnibor_clear_deps (void);
 void omnibor_clear_note_sections (void);
-void omnibor_get_destdir (char **);
 void write_sha1_omnibor (char **, const char *);
 void write_sha256_omnibor (char **, const char *);
 void create_sha1_symlink (const char *, char *);

--- a/binutils-2.39/gas/doc/as.texi
+++ b/binutils-2.39/gas/doc/as.texi
@@ -2381,7 +2381,7 @@ assembler.)
 * MD::            --MD for dependency tracking
 * no-pad-sections:: --no-pad-sections to stop section padding
 * o::             -o to name the object file
-* omnibor::	  --omnibor for OmniBOR calculation
+* omnibor::	  --omnibor=<dir> for OmniBOR calculation
 * omnibor-tempfile:: --omnibor-tempfile to specify that the input file is temporary
 * R::             -R to join data and text sections
 * statistics::    --statistics to see statistics about assembly

--- a/binutils-2.39/gas/testsuite/gas/elf/omnibor.exp
+++ b/binutils-2.39/gas/testsuite/gas/elf/omnibor.exp
@@ -69,26 +69,22 @@ proc check_omnibor_document_contents_sha256 { omnibor_file test_name } {
 
 set env(OMNIBOR_DIR) "env_dir"
 
-run_dump_test "omnibor" [list [list as --omnibor] [list warning ".*"]]
 run_dump_test "omnibor" [list [list as --omnibor=dir] [list warning ".*"]]
+
+check_omnibor_document_contents_sha1 "dir/objects/gitoid_blob_sha1/fe/2bd8f74815e578a2eed695357239e54fe88848" "OmniBOR SHA1 Document file contents 1"
+
+check_omnibor_document_contents_sha256 "dir/objects/gitoid_blob_sha256/58/fc982259aecdb07634390a8b4ba1ac3024c40ac1f2770a17451c87cf2e313c" "OmniBOR SHA256 Document file contents 1"
+
 run_dump_test "omnibor" [list [list warning ".*"]]
 
-check_omnibor_document_contents_sha1 "env_dir/objects/gitoid_blob_sha1/fe/2bd8f74815e578a2eed695357239e54fe88848" "OmniBOR SHA1 Document file contents 1"
+check_omnibor_document_contents_sha1 "env_dir/objects/gitoid_blob_sha1/fe/2bd8f74815e578a2eed695357239e54fe88848" "OmniBOR SHA1 Document file contents 2"
 
-check_omnibor_document_contents_sha256 "env_dir/objects/gitoid_blob_sha256/58/fc982259aecdb07634390a8b4ba1ac3024c40ac1f2770a17451c87cf2e313c" "OmniBOR SHA256 Document file contents 1"
+check_omnibor_document_contents_sha256 "env_dir/objects/gitoid_blob_sha256/58/fc982259aecdb07634390a8b4ba1ac3024c40ac1f2770a17451c87cf2e313c" "OmniBOR SHA256 Document file contents 2"
 
 unset env(OMNIBOR_DIR)
 
-run_dump_test "omnibor" [list [list as --omnibor] [list warning ".*"]]
+run_dump_test "omnibor" [list [list as --omnibor=option_dir] [list warning ".*"]]
 
-# OmniBOR information is stored in tmpdir because the resulting object file is stored there
-check_omnibor_document_contents_sha1 "tmpdir/objects/gitoid_blob_sha1/fe/2bd8f74815e578a2eed695357239e54fe88848" "OmniBOR SHA1 Document file contents 2"
+check_omnibor_document_contents_sha1 "option_dir/objects/gitoid_blob_sha1/fe/2bd8f74815e578a2eed695357239e54fe88848" "OmniBOR SHA1 Document file contents 3"
 
-# OmniBOR information is stored in tmpdir because the resulting object file is stored there
-check_omnibor_document_contents_sha256 "tmpdir/objects/gitoid_blob_sha256/58/fc982259aecdb07634390a8b4ba1ac3024c40ac1f2770a17451c87cf2e313c" "OmniBOR SHA256 Document file contents 2"
-
-run_dump_test "omnibor" [list [list as --omnibor=dir] [list warning ".*"]]
-
-check_omnibor_document_contents_sha1 "dir/objects/gitoid_blob_sha1/fe/2bd8f74815e578a2eed695357239e54fe88848" "OmniBOR SHA1 Document file contents 3"
-
-check_omnibor_document_contents_sha256 "dir/objects/gitoid_blob_sha256/58/fc982259aecdb07634390a8b4ba1ac3024c40ac1f2770a17451c87cf2e313c" "OmniBOR SHA256 Document file contents 3"
+check_omnibor_document_contents_sha256 "option_dir/objects/gitoid_blob_sha256/58/fc982259aecdb07634390a8b4ba1ac3024c40ac1f2770a17451c87cf2e313c" "OmniBOR SHA256 Document file contents 3"

--- a/binutils-2.39/ld/ld.h
+++ b/binutils-2.39/ld/ld.h
@@ -285,7 +285,7 @@ typedef struct
   char *dependency_file;
 
   /* The path to the directory where the OmniBOR information should be
-     placed, unless OMNIBOR_DIR environment variable is set.  */
+     placed.  */
   char *omnibor_dir;
 
   unsigned int split_by_reloc;

--- a/binutils-2.39/ld/ld.info
+++ b/binutils-2.39/ld/ld.info
@@ -622,14 +622,11 @@ GNU linker:
      installation where it was produced, and should not be copied into
      distributed makefiles without careful editing.
 
-'--omnibor'
 '--omnibor=DIRECTORY'
      Calculate the 'OmniBOR' information.  Use DIRECTORY as the path to the
      directory in which the 'OmniBOR' information should be stored.  This
-     option has precedence over the default case (when DIRECTORY is not
-     specified), but lower priority compared to the 'OMNIBOR_DIR'
-     environment variable.  In the default case, the 'OmniBOR' information
-     is stored in the same directory as the resulting executable.
+     option has precedence over the case when the 'OMNIBOR_DIR' environment
+     variable is set.
 
 '-O LEVEL'
      If LEVEL is a numeric values greater than zero 'ld' optimizes the
@@ -8495,7 +8492,6 @@ LD Index
 * --format=VERSION:                      TI COFF.            (line    6)
 * --gc-keep-exported:                    Options.            (line 1453)
 * --gc-sections:                         Options.            (line 1415)
-* --omnibor:                             Options.            (line 625)
 * --omnibor=DIRECTORY:                   Options.            (line 625)
 * --got:                                 Options.            (line 2808)
 * --got=TYPE:                            M68K.               (line    6)

--- a/binutils-2.39/ld/ld.texi
+++ b/binutils-2.39/ld/ld.texi
@@ -909,16 +909,13 @@ linker, unlike ``system headers'' in the compiler).  So the output from
 installation where it was produced, and should not be copied into
 distributed makefiles without careful editing.
 
-@kindex --omnibor
 @kindex --omnibor=@var{directory}
-@item --omnibor
-@itemx --omnibor=@var{directory}
+@cindex enabling OmniBOR calculation
+@item --omnibor=@var{directory}
 Calculate the @code{OmniBOR} information.  Use @var{directory} as the path
 to the directory in which the @code{OmniBOR} information should be stored.
-This option has precedence over the default case (when @var{directory} is
-not specified), but lower priority compared to the @code{OMNIBOR_DIR}
-environment variable.  In the default case, the @code{OmniBOR} information
-is stored in the same directory as the resulting executable.
+This option has precedence over the case when the @code{OMNIBOR_DIR}
+environment variable is set.
 
 @kindex -O @var{level}
 @cindex generating optimized output

--- a/binutils-2.39/ld/ldelf.c
+++ b/binutils-2.39/ld/ldelf.c
@@ -1727,7 +1727,7 @@ write_omnibor (bfd *abfd)
   if (bfd_is_abs_section (asec->output_section))
     {
       einfo (_("%P: warning: .note.omnibor section discarded,"
-	       " --omnibor ignored\n"));
+	       " --omnibor= ignored\n"));
       return true;
     }
   i_shdr = &elf_section_data (asec->output_section)->this_hdr;
@@ -1818,7 +1818,7 @@ ldelf_setup_omnibor (bfd *ibfd)
     }
 
   einfo (_("%P: warning: cannot create .note.omnibor section,"
-	   " --omnibor ignored\n"));
+	   " --omnibor= ignored\n"));
   return false;
 }
 

--- a/binutils-2.39/ld/lexsup.c
+++ b/binutils-2.39/ld/lexsup.c
@@ -149,7 +149,7 @@ static const struct ld_option ld_options[] =
   { {"gpsize", required_argument, NULL, 'G'},
     'G', N_("SIZE"), N_("Small data size (if no size, same as --shared)"),
     TWO_DASHES },
-  { {"omnibor", optional_argument, NULL, OPTION_OMNIBOR},
+  { {"omnibor", required_argument, NULL, OPTION_OMNIBOR},
     '\0', N_("DIRECTORY"), N_("Calculate OmniBOR information"), TWO_DASHES },
   { {"soname", required_argument, NULL, OPTION_SONAME},
     'h', N_("FILENAME"), N_("Set internal name of shared library"), ONE_DASH },
@@ -1754,10 +1754,10 @@ parse_args (unsigned argc, char **argv)
 		(char *) xcalloc (2 * GITOID_LENGTH_SHA1 + 1, sizeof (char));
 	  ldelf_emit_note_omnibor_sha256 =
 		(char *) xcalloc (2 * GITOID_LENGTH_SHA256 + 1, sizeof (char));
-	  if (optarg != NULL)
+	  if (optarg != NULL && strlen (optarg) > 0)
 	    config.omnibor_dir = optarg;
 	  else
-	    config.omnibor_dir = "";
+	    einfo (_("%P: expected argument to --omnibor= but none provided\n"));
 	  break;
 	}
     }

--- a/binutils-2.39/ld/testsuite/ld-elf/omnibor.exp
+++ b/binutils-2.39/ld/testsuite/ld-elf/omnibor.exp
@@ -25,7 +25,7 @@ if ![is_elf_format] {
     return
 }
 
-proc check_omnibor_document_contents_sha1 { omnibor_file test_name } {
+proc check_omnibor_document_contents_sha1 { omnibor_file test_name contents } {
     if [file exists $omnibor_file] then {
         set file_a [open $omnibor_file r]
     } else {
@@ -40,7 +40,7 @@ proc check_omnibor_document_contents_sha1 { omnibor_file test_name } {
     }
     close $file_a
 
-    if { [regexp "^gitoid:blob:sha1 {blob d138dc90198e9370085e65f8bfec82d81e245c56}$" $list_a] } then {
+    if { [regexp $contents $list_a] } then {
         pass $test_name
     } else {
         perror "$list_a"
@@ -49,7 +49,7 @@ proc check_omnibor_document_contents_sha1 { omnibor_file test_name } {
     return 0
 }
 
-proc check_omnibor_document_contents_sha256 { omnibor_file test_name } {
+proc check_omnibor_document_contents_sha256 { omnibor_file test_name contents } {
     if [file exists $omnibor_file] then {
         set file_a [open $omnibor_file r]
     } else {
@@ -64,7 +64,7 @@ proc check_omnibor_document_contents_sha256 { omnibor_file test_name } {
     }
     close $file_a
 
-    if { [regexp "^gitoid:blob:sha256 {blob c3d71ad569a20d9c13a2fadcfce2c254d1a61151edd5e9958d5fdc238d431693}$" $list_a] } then {
+    if { [regexp $contents $list_a] } then {
         pass $test_name
     } else {
         perror "$list_a"
@@ -77,14 +77,21 @@ set env(OMNIBOR_DIR) "env_dir"
 
 run_ld_link_tests [list \
     [list \
-	"OmniBOR calculation with OMNIBOR_DIR and --omnibor" \
-	"-r --omnibor" \
+	"OmniBOR calculation with OMNIBOR_DIR and --omnibor=dir" \
+	"-r --omnibor=dir" \
 	"" \
 	"" \
 	{dummy.s} \
 	{{readelf {--notes} omnibor.rd}} \
 	"omnibor1.o" \
     ] \
+]
+
+check_omnibor_document_contents_sha1 "dir/objects/gitoid_blob_sha1/6b/0ac07f1736ad1ab3827034891ef9b03639a9ed" "OmniBOR SHA1 Document file contents 1" "^gitoid:blob:sha1 {blob 4ce706e35bbd9f9b5ea77dfa4337417b3859aaa4 bom a965126fdde0463cb4718528cab7081e92b9e140}$"
+
+check_omnibor_document_contents_sha256 "dir/objects/gitoid_blob_sha256/4f/1fa8a498c16fdcd24d5d9c909e2a69e8c2d14574154c3ca8d76a3f6ede639c" "OmniBOR SHA256 Document file contents 1" "^gitoid:blob:sha256 {blob 89049366024b9ff5aaf9efd137248849f4a611c4b4049e063c3ef5326bf437ca bom 6d8d98ed995192169a6522b0d4f03948c9991de507e4fc14b012f07be2581752}$"
+
+run_ld_link_tests [list \
     [list \
 	"OmniBOR calculation with OMNIBOR_DIR" \
 	"-r" \
@@ -94,9 +101,18 @@ run_ld_link_tests [list \
 	{{readelf {--notes} omnibor.rd}} \
 	"omnibor2.o" \
     ] \
+]
+
+check_omnibor_document_contents_sha1 "env_dir/objects/gitoid_blob_sha1/6b/0ac07f1736ad1ab3827034891ef9b03639a9ed" "OmniBOR SHA1 Document file contents 2" "^gitoid:blob:sha1 {blob 4ce706e35bbd9f9b5ea77dfa4337417b3859aaa4 bom a965126fdde0463cb4718528cab7081e92b9e140}$"
+
+check_omnibor_document_contents_sha256 "env_dir/objects/gitoid_blob_sha256/4f/1fa8a498c16fdcd24d5d9c909e2a69e8c2d14574154c3ca8d76a3f6ede639c" "OmniBOR SHA256 Document file contents 2" "^gitoid:blob:sha256 {blob 89049366024b9ff5aaf9efd137248849f4a611c4b4049e063c3ef5326bf437ca bom 6d8d98ed995192169a6522b0d4f03948c9991de507e4fc14b012f07be2581752}$"
+
+unset env(OMNIBOR_DIR)
+
+run_ld_link_tests [list \
     [list \
-	"OmniBOR calculation with OMNIBOR_DIR and --omnibor=dir" \
-	"-r --omnibor=dir" \
+	"OmniBOR calculation with --omnibor=dir" \
+	"-r --omnibor=option_dir" \
 	"" \
 	"" \
 	{dummy.s} \
@@ -105,42 +121,10 @@ run_ld_link_tests [list \
     ] \
 ]
 
-check_omnibor_document_contents_sha1 "env_dir/objects/gitoid_blob_sha1/05/33256bbdc60cd8d714d4f54d0d81c0964b7db6" "OmniBOR SHA1 Document file contents 1"
+# The OmniBOR Document files are different in the following case compared to the previous two
+# cases because now the OmniBOR calculation is not enabled in GNU assembler, since the GNU ld
+# OmniBOR option is used and the OMNIBOR_DIR environment variable is not set.
 
-check_omnibor_document_contents_sha256 "env_dir/objects/gitoid_blob_sha256/40/c1311813b76afac737d6223b4e632c4054019f7fcf89ccb0d8823f8d4fe239" "OmniBOR SHA256 Document file contents 1"
+check_omnibor_document_contents_sha1 "option_dir/objects/gitoid_blob_sha1/05/33256bbdc60cd8d714d4f54d0d81c0964b7db6" "OmniBOR SHA1 Document file contents 3" "^gitoid:blob:sha1 {blob d138dc90198e9370085e65f8bfec82d81e245c56}$"
 
-unset env(OMNIBOR_DIR)
-
-run_ld_link_tests [list \
-    [list \
-	"OmniBOR calculation with --omnibor=dir" \
-	"-r --omnibor=dir" \
-	"" \
-	"" \
-	{dummy.s} \
-	{{readelf {--notes} omnibor.rd}} \
-	"omnibor4.o" \
-    ] \
-]
-
-check_omnibor_document_contents_sha1 "dir/objects/gitoid_blob_sha1/05/33256bbdc60cd8d714d4f54d0d81c0964b7db6" "OmniBOR SHA1 Document file contents 2"
-
-check_omnibor_document_contents_sha256 "dir/objects/gitoid_blob_sha256/40/c1311813b76afac737d6223b4e632c4054019f7fcf89ccb0d8823f8d4fe239" "OmniBOR SHA256 Document file contents 2"
-
-run_ld_link_tests [list \
-    [list \
-	"OmniBOR calculation with --omnibor" \
-	"-r --omnibor" \
-	"" \
-	"" \
-	{dummy.s} \
-	{{readelf {--notes} omnibor.rd}} \
-	"omnibor5.o" \
-    ] \
-]
-
-# OmniBOR information is stored in tmpdir because the resulting executable is stored there
-check_omnibor_document_contents_sha1 "tmpdir/objects/gitoid_blob_sha1/05/33256bbdc60cd8d714d4f54d0d81c0964b7db6" "OmniBOR SHA1 Document file contents 3"
-
-# OmniBOR information is stored in tmpdir because the resulting executable is stored there
-check_omnibor_document_contents_sha256 "tmpdir/objects/gitoid_blob_sha256/40/c1311813b76afac737d6223b4e632c4054019f7fcf89ccb0d8823f8d4fe239" "OmniBOR SHA256 Document file contents 3"
+check_omnibor_document_contents_sha256 "option_dir/objects/gitoid_blob_sha256/40/c1311813b76afac737d6223b4e632c4054019f7fcf89ccb0d8823f8d4fe239" "OmniBOR SHA256 Document file contents 3" "^gitoid:blob:sha256 {blob c3d71ad569a20d9c13a2fadcfce2c254d1a61151edd5e9958d5fdc238d431693}$"


### PR DESCRIPTION
This PR contains changes to the way the directory in which the OmniBOR information should be stored is determined, which OmniBOR spec approved.

There are two main changes:
          1) The build option --omnibor both for GNU ld and GNU as does not have an optional argument anymore, but instead a required one. This is due to the fact that the default behaviour for OmniBOR build options was removed.
          2) The build option takes precedence over the OMNIBOR_DIR environment variable, in case both are specified.